### PR TITLE
다크모드 : 리스트 타일 테마 설정

### DIFF
--- a/lib/utils/AppTheme.dart
+++ b/lib/utils/AppTheme.dart
@@ -4,6 +4,14 @@ import 'AppDialogStyle.dart';
 import 'AppTextStyle.dart';
 
 final ThemeData lightTheme = ThemeData(
+  listTileTheme: const ListTileThemeData(
+    tileColor: white,
+    textColor: black,
+    contentPadding: EdgeInsets.symmetric(horizontal: 20),
+    horizontalTitleGap: 0,
+    minVerticalPadding: 0,
+    dense: true,
+  ),
   colorScheme: ColorScheme.fromSeed(
     seedColor: white,
     primary: black,
@@ -17,14 +25,21 @@ final ThemeData lightTheme = ThemeData(
     titleTextStyle: black16BoldTextStyle,
   ),
   textTheme: const TextTheme(
-    bodyLarge: black16TextStyle,
-    bodyMedium: black12TextStyle,
     bodySmall: black12TextStyle,
-    labelMedium: black16TextStyle,
+    bodyMedium: black12TextStyle,
+    bodyLarge: black16TextStyle,
     labelSmall: grey13TextStyle,
-    titleLarge: black16TextStyle,
-    titleMedium: black12BoldTextStyle,
+    labelMedium: black16TextStyle,
+    labelLarge: black16TextStyle,
     titleSmall: black12BoldTextStyle,
+    titleMedium: black12BoldTextStyle,
+    titleLarge: black16TextStyle,
+    displaySmall: grey13TextStyle,
+    displayMedium: black16TextStyle,
+    displayLarge: black16TextStyle,
+    headlineSmall: black12BoldTextStyle,
+    headlineMedium: black12BoldTextStyle,
+    headlineLarge: black16TextStyle,
   ),
   extensions: const <ThemeExtension<dynamic>>{
     DialogStyle(),
@@ -34,10 +49,18 @@ final ThemeData lightTheme = ThemeData(
 );
 
 final ThemeData darkTheme = ThemeData(
+  listTileTheme: const ListTileThemeData(
+    tileColor: black,
+    textColor: white,
+    contentPadding: EdgeInsets.symmetric(horizontal: 20),
+    horizontalTitleGap: 0,
+    minVerticalPadding: 0,
+    dense: true,
+  ),
   colorScheme: ColorScheme.fromSeed(
-    seedColor: black,
-    primary: Colors.black,
-    secondary: greySecondary,
+    seedColor: white,
+    primary: black,
+    secondary: greySecondary
   ),
   appBarTheme: const AppBarTheme(
     color: black,
@@ -47,14 +70,21 @@ final ThemeData darkTheme = ThemeData(
     titleTextStyle: white16BoldTextStyle,
   ),
   textTheme: const TextTheme(
-    bodyLarge: white16TextStyle,
-    bodyMedium: white12TextStyle,
     bodySmall: white12TextStyle,
-    labelMedium: white16TextStyle,
+    bodyMedium: white12TextStyle,
+    bodyLarge: white16TextStyle,
     labelSmall: grey13TextStyle,
-    titleLarge: white16TextStyle,
-    titleMedium: white12BoldTextStyle,
+    labelMedium: white16TextStyle,
+    labelLarge: white16TextStyle,
     titleSmall: white12BoldTextStyle,
+    titleMedium: white12BoldTextStyle,
+    titleLarge: white16TextStyle,
+    displaySmall: grey13TextStyle,
+    displayMedium: white16TextStyle,
+    displayLarge: white16TextStyle,
+    headlineSmall: white12BoldTextStyle,
+    headlineMedium: white12BoldTextStyle,
+    headlineLarge: white16TextStyle,
   ),
   extensions: const <ThemeExtension<dynamic>>{
     DialogStyle(),


### PR DESCRIPTION
## 설명
다크모드에서 리스트 타일만 색상 적용이 안되어서 수정해뒀습니다.

## 변경 사항

- 다크모드에서 리스트 타일만 색상 적용이 안되어서 수정해뒀습니다.

## 체크리스트
< 체크리스트 항목을 확인해 주세요. >

- [x] 오늘도 행복하게 코딩했는가?
- [x] release 브랜치를 제대로 최신화 하고 이 브랜치에 merge 했는가?
- [x] PR 제목은 명확하고 간결한가?
- [x] PR 에는 하나의 작업에 대한 내용만 포함되었는가?
- [x] 파일명은 누구나 이해할 수 있게 작성되었는가?
- [x] camelCase를 사용하였는가? (ThisIsCamelCase, this_is_not_camel_case)
- [x] 텍스트는 AppStrings.dart 파일에서 가져오고 있는가?
- [x] 디스코드 채팅방에 완료된 태스크를 알렸는가?

## 스크린샷
< 여기에 이미지/동영상을 드래그 앤 드랍하면 링크가 생성됩니다. > 
<img alt="sample" width="240" src="https://github.com/user-attachments/assets/d004116d-319d-4e34-88f8-9c46f8bb8e3e">

## 참조

관련된 이슈나 PR이 있다면 링크를 추가해주세요.
