### PR TITLE
닉네임 프로바이더 + 닉네임 위젯 생성

### DIFF
--- a/lib/providers/MyPageNameProvider.dart
+++ b/lib/providers/MyPageNameProvider.dart
@@ -1,0 +1,16 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final myPageNicknameProvider = StreamProvider<String>((ref) {
+  final firestore = FirebaseFirestore.instance;
+  final userId = FirebaseAuth.instance.currentUser!.uid;
+
+  return firestore
+      .collection('users')
+      .doc(userId)
+      .snapshots()
+      .map((snapshot) {
+    return snapshot['name'] as String;
+  });
+});

--- a/lib/screens/mypage/MyPageScreen.dart
+++ b/lib/screens/mypage/MyPageScreen.dart
@@ -39,7 +39,7 @@ class MyPageScreen extends ConsumerWidget {
             Row(
               children: [
                 profileImageStack(profileImage, ref, context),
-                Expanded(
+                const Expanded(
                   child: Column(
                     mainAxisAlignment: MainAxisAlignment.start,
                     children: [

--- a/lib/screens/mypage/MyPageScreen.dart
+++ b/lib/screens/mypage/MyPageScreen.dart
@@ -27,186 +27,183 @@ class MyPageScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final profileImage = ref.watch(profileImageStreamProvider);
 
-    return Padding(
-      padding: const EdgeInsets.all(8.0),
-      child: Scaffold(
-        appBar: AppBar(
-          title: const Text(AppStrings.myPageTitle),
-        ),
-        body: Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                children: [
-                  profileImageStack(profileImage, ref, context),
-                  Expanded(
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.start,
-                      children: [
-                        NickNameTextWidget(),
-                        Text("Google 로그인을 사용 중 입니다.")
-                      ],
-                    ),
-                  )
-                ],
-              ),
-              const SizedBox(
-                height: 40,
-              ),
-              const CustomDividerWidget(),
-              GestureDetector(
-                onTap: () {
-                  Navigator.of(context).push(MaterialPageRoute(
-                    builder: (context) => const FixSettingAccountManager(),
-                  ));
-                },
-                child: const ListTile(
-                  leading: Icon(Icons.person),
-                  title: Text(
-                    "관리",
-                    style: TextStyle(fontSize: 20),
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(AppStrings.myPageTitle),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                profileImageStack(profileImage, ref, context),
+                Expanded(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    children: [
+                      NickNameTextWidget(),
+                      Text("Google 로그인을 사용 중 입니다.")
+                    ],
                   ),
+                )
+              ],
+            ),
+            const SizedBox(
+              height: 40,
+            ),
+            const CustomDividerWidget(),
+            GestureDetector(
+              onTap: () {
+                Navigator.of(context).push(MaterialPageRoute(
+                  builder: (context) => const FixSettingAccountManager(),
+                ));
+              },
+              child: const ListTile(
+                leading: Icon(Icons.person),
+                title: Text(
+                  "관리",
+                  style: TextStyle(fontSize: 20),
                 ),
               ),
-              const CustomDividerWidget(),
-              GestureDetector(
-                onTap: () {},
-                child: const ListTile(
-                  leading: Icon(Icons.card_membership),
-                  title: Text(
-                    "결제 정보",
-                    style: TextStyle(fontSize: 20),
-                  ),
+            ),
+            const CustomDividerWidget(),
+            GestureDetector(
+              onTap: () {},
+              child: const ListTile(
+                leading: Icon(Icons.card_membership),
+                title: Text(
+                  "결제 정보",
+                  style: TextStyle(fontSize: 20),
                 ),
               ),
-              const CustomDividerWidget(),
-              GestureDetector(
-                onTap: () {},
-                child: const ListTile(
-                  leading: Icon(Icons.alarm_add_outlined),
-                  title: Text(
-                    "알림",
-                    style: TextStyle(fontSize: 20),
-                  ),
+            ),
+            const CustomDividerWidget(),
+            GestureDetector(
+              onTap: () {},
+              child: const ListTile(
+                leading: Icon(Icons.alarm_add_outlined),
+                title: Text(
+                  "알림",
+                  style: TextStyle(fontSize: 20),
                 ),
               ),
-              const CustomDividerWidget(),
-              GestureDetector(
-                onTap: () {},
-                child: const ListTile(
-                  leading: Icon(Icons.lock),
-                  title: Text(
-                    "개인 / 보안",
-                    style: TextStyle(fontSize: 20),
-                  ),
+            ),
+            const CustomDividerWidget(),
+            GestureDetector(
+              onTap: () {},
+              child: const ListTile(
+                leading: Icon(Icons.lock),
+                title: Text(
+                  "개인 / 보안",
+                  style: TextStyle(fontSize: 20),
                 ),
               ),
-              const CustomDividerWidget(),
-              GestureDetector(
-                onTap: () {},
-                child: const ListTile(
-                  leading: Icon(Icons.monitor),
-                  title: Text(
-                    "테마",
-                    style: TextStyle(fontSize: 20),
-                  ),
+            ),
+            const CustomDividerWidget(),
+            GestureDetector(
+              onTap: () {},
+              child: const ListTile(
+                leading: Icon(Icons.monitor),
+                title: Text(
+                  "테마",
+                  style: TextStyle(fontSize: 20),
                 ),
               ),
-              const CustomDividerWidget(),
-              GestureDetector(
-                onTap: () {
-                  Navigator.of(context).push(MaterialPageRoute(
-                    builder: (context) => const FixSettingCameraMediaPage(),
-                  ));
-                },
-                child: const ListTile(
-                  leading: Icon(Icons.chat_bubble_outline),
-                  title: Text(
-                    "채팅 / 미디어",
-                    style: TextStyle(fontSize: 20),
-                  ),
+            ),
+            const CustomDividerWidget(),
+            GestureDetector(
+              onTap: () {
+                Navigator.of(context).push(MaterialPageRoute(
+                  builder: (context) => const FixSettingCameraMediaPage(),
+                ));
+              },
+              child: const ListTile(
+                leading: Icon(Icons.chat_bubble_outline),
+                title: Text(
+                  "채팅 / 미디어",
+                  style: TextStyle(fontSize: 20),
                 ),
               ),
-              const SizedBox(
-                height: 30,
-              ),
-              const CustomDividerWidget(),
-              GestureDetector(
-                onTap: () {
-                  Navigator.push(context, MaterialPageRoute(builder: (context) {
-                    return const SettingScreen();
-                  }));
-                },
-                child: const ListTile(
-                  leading: Icon(Icons.notifications),
-                  title: Text(
-                    "설정",
-                    style: TextStyle(fontSize: 20),
-                  ),
+            ),
+            const SizedBox(
+              height: 30,
+            ),
+            const CustomDividerWidget(),
+            GestureDetector(
+              onTap: () {
+                Navigator.push(context, MaterialPageRoute(builder: (context) {
+                  return const SettingScreen();
+                }));
+              },
+              child: const ListTile(
+                leading: Icon(Icons.notifications),
+                title: Text(
+                  "설정",
+                  style: TextStyle(fontSize: 20),
                 ),
               ),
-              const CustomDividerWidget(),
+            ),
+            const CustomDividerWidget(),
 
-              //Logout button
-              GestureDetector(
-                onTap: () {
-                  ref.read(firebaseAuthServiceProvider).signOut();
-                },
-                child: const ListTile(
-                  leading: Icon(Icons.logout),
-                  title: Text(
-                    "로그아웃",
-                    style: TextStyle(fontSize: 20),
-                  ),
+            //Logout button
+            GestureDetector(
+              onTap: () {
+                ref.read(firebaseAuthServiceProvider).signOut();
+              },
+              child: const ListTile(
+                leading: Icon(Icons.logout),
+                title: Text(
+                  "로그아웃",
+                  style: TextStyle(fontSize: 20),
                 ),
               ),
+            ),
 
-              //Logout button
-              GestureDetector(
-                onTap: () async {
-                  try {
-                    final re = await engine.deleteAccount();
-                    debugPrint(re.toString());
-                    if (context.mounted) {
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(
-                          content: Text('회원탈퇴가 완료되었습니다.'),
-                        ),
-                      );
-                    }
-                    ref.read(firebaseAuthServiceProvider).signOut();
-                  } on FirebaseFunctionsException catch (e) {
-                    if (context.mounted) {
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(
-                          content: Text('Error: ${e.code}/${e.message}'),
-                        ),
-                      );
-                    }
-                  } catch (e) {
-                    if (context.mounted) {
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(
-                          content: Text(
-                              'Error: $e'), // e.code: internal, e.message: INTERNAL
-                        ),
-                      );
-                    }
+            //Logout button
+            GestureDetector(
+              onTap: () async {
+                try {
+                  final re = await engine.deleteAccount();
+                  debugPrint(re.toString());
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        content: Text('회원탈퇴가 완료되었습니다.'),
+                      ),
+                    );
                   }
-                },
-                child: const Expanded(
-                    child: ListTile(
-                  leading: Icon(Icons.person_off),
-                  title: Text(
-                    "회원탈퇴",
-                    style: TextStyle(fontSize: 20),
-                  ),
-                )),
-              ),
-            ],
-          ),
+                  ref.read(firebaseAuthServiceProvider).signOut();
+                } on FirebaseFunctionsException catch (e) {
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text('Error: ${e.code}/${e.message}'),
+                      ),
+                    );
+                  }
+                } catch (e) {
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text(
+                            'Error: $e'), // e.code: internal, e.message: INTERNAL
+                      ),
+                    );
+                  }
+                }
+              },
+              child: const Expanded(
+                  child: ListTile(
+                leading: Icon(Icons.person_off),
+                title: Text(
+                  "회원탈퇴",
+                  style: TextStyle(fontSize: 20),
+                ),
+              )),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/screens/mypage/MyPageScreen.dart
+++ b/lib/screens/mypage/MyPageScreen.dart
@@ -38,14 +38,16 @@ class MyPageScreen extends ConsumerWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              NickNameTextWidget(),
               Row(
                 children: [
                   profileImageStack(profileImage, ref, context),
                   Expanded(
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.start,
-                      children: [Text("Google 로그인을 사용 중 입니다.")],
+                      children: [
+                        NickNameTextWidget(),
+                        Text("Google 로그인을 사용 중 입니다.")
+                      ],
                     ),
                   )
                 ],

--- a/lib/screens/mypage/MyPageScreen.dart
+++ b/lib/screens/mypage/MyPageScreen.dart
@@ -14,7 +14,9 @@ import '../../providers/camera/FirebaseStoreServiceProvider.dart';
 import '../../providers/camera/fireStorageServiceProvider.dart';
 import '../../providers/user/FirebaseAuthServiceProvider.dart';
 import '../../providers/user/ProfileImageProvider.dart';
+import '../../utils/AppStrings.dart';
 import '../../widgets/CustomDividerWidget.dart';
+import '../../widgets/NickNameTextWidget.dart';
 import '../SettingScreen.dart';
 import 'camera/SettingsBottomSheet.dart';
 
@@ -25,187 +27,184 @@ class MyPageScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final profileImage = ref.watch(profileImageStreamProvider);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('My Page'),
-      ),
-      body: Padding(
-        padding: const EdgeInsets.all(8.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                profileImageStack(profileImage, ref, context),
-                const Expanded(
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.start,
-                    children: [
-                      Text(
-                        "userID or userNickName",
-                        style: TextStyle(
-                            fontSize: 20, fontWeight: FontWeight.bold),
-                      ),
-                      Text("Google 로그인을 사용 중 입니다.")
-                    ],
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text(AppStrings.myPageTitle),
+        ),
+        body: Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              NickNameTextWidget(),
+              Row(
+                children: [
+                  profileImageStack(profileImage, ref, context),
+                  Expanded(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.start,
+                      children: [Text("Google 로그인을 사용 중 입니다.")],
+                    ),
+                  )
+                ],
+              ),
+              const SizedBox(
+                height: 40,
+              ),
+              const CustomDividerWidget(),
+              GestureDetector(
+                onTap: () {
+                  Navigator.of(context).push(MaterialPageRoute(
+                    builder: (context) => const FixSettingAccountManager(),
+                  ));
+                },
+                child: const ListTile(
+                  leading: Icon(Icons.person),
+                  title: Text(
+                    "관리",
+                    style: TextStyle(fontSize: 20),
                   ),
-                )
-              ],
-            ),
-            const SizedBox(
-              height: 40,
-            ),
-            const CustomDividerWidget(),
-            GestureDetector(
-              onTap: () {
-                Navigator.of(context).push(MaterialPageRoute(
-                  builder: (context) => const FixSettingAccountManager(),
-                ));
-              },
-              child: const ListTile(
-                leading: Icon(Icons.person),
-                title: Text(
-                  "관리",
-                  style: TextStyle(fontSize: 20),
                 ),
               ),
-            ),
-            const CustomDividerWidget(),
-            GestureDetector(
-              onTap: () {},
-              child: const ListTile(
-                leading: Icon(Icons.card_membership),
-                title: Text(
-                  "결제 정보",
-                  style: TextStyle(fontSize: 20),
+              const CustomDividerWidget(),
+              GestureDetector(
+                onTap: () {},
+                child: const ListTile(
+                  leading: Icon(Icons.card_membership),
+                  title: Text(
+                    "결제 정보",
+                    style: TextStyle(fontSize: 20),
+                  ),
                 ),
               ),
-            ),
-            const CustomDividerWidget(),
-            GestureDetector(
-              onTap: () {},
-              child: const ListTile(
-                leading: Icon(Icons.alarm_add_outlined),
-                title: Text(
-                  "알림",
-                  style: TextStyle(fontSize: 20),
+              const CustomDividerWidget(),
+              GestureDetector(
+                onTap: () {},
+                child: const ListTile(
+                  leading: Icon(Icons.alarm_add_outlined),
+                  title: Text(
+                    "알림",
+                    style: TextStyle(fontSize: 20),
+                  ),
                 ),
               ),
-            ),
-            const CustomDividerWidget(),
-            GestureDetector(
-              onTap: () {},
-              child: const ListTile(
-                leading: Icon(Icons.lock),
-                title: Text(
-                  "개인 / 보안",
-                  style: TextStyle(fontSize: 20),
+              const CustomDividerWidget(),
+              GestureDetector(
+                onTap: () {},
+                child: const ListTile(
+                  leading: Icon(Icons.lock),
+                  title: Text(
+                    "개인 / 보안",
+                    style: TextStyle(fontSize: 20),
+                  ),
                 ),
               ),
-            ),
-            const CustomDividerWidget(),
-            GestureDetector(
-              onTap: () {},
-              child: const ListTile(
-                leading: Icon(Icons.monitor),
-                title: Text(
-                  "테마",
-                  style: TextStyle(fontSize: 20),
+              const CustomDividerWidget(),
+              GestureDetector(
+                onTap: () {},
+                child: const ListTile(
+                  leading: Icon(Icons.monitor),
+                  title: Text(
+                    "테마",
+                    style: TextStyle(fontSize: 20),
+                  ),
                 ),
               ),
-            ),
-            const CustomDividerWidget(),
-            GestureDetector(
-              onTap: () {
-                Navigator.of(context).push(MaterialPageRoute(
-                  builder: (context) => const FixSettingCameraMediaPage(),
-                ));
-              },
-              child: const ListTile(
-                leading: Icon(Icons.chat_bubble_outline),
-                title: Text(
-                  "채팅 / 미디어",
-                  style: TextStyle(fontSize: 20),
+              const CustomDividerWidget(),
+              GestureDetector(
+                onTap: () {
+                  Navigator.of(context).push(MaterialPageRoute(
+                    builder: (context) => const FixSettingCameraMediaPage(),
+                  ));
+                },
+                child: const ListTile(
+                  leading: Icon(Icons.chat_bubble_outline),
+                  title: Text(
+                    "채팅 / 미디어",
+                    style: TextStyle(fontSize: 20),
+                  ),
                 ),
               ),
-            ),
-            const SizedBox(
-              height: 30,
-            ),
-            const CustomDividerWidget(),
-            GestureDetector(
-              onTap: () {
-                Navigator.push(context, MaterialPageRoute(builder: (context) {
-                  return const SettingScreen();
-                }));
-              },
-              child: const ListTile(
-                leading: Icon(Icons.notifications),
-                title: Text(
-                  "설정",
-                  style: TextStyle(fontSize: 20),
+              const SizedBox(
+                height: 30,
+              ),
+              const CustomDividerWidget(),
+              GestureDetector(
+                onTap: () {
+                  Navigator.push(context, MaterialPageRoute(builder: (context) {
+                    return const SettingScreen();
+                  }));
+                },
+                child: const ListTile(
+                  leading: Icon(Icons.notifications),
+                  title: Text(
+                    "설정",
+                    style: TextStyle(fontSize: 20),
+                  ),
                 ),
               ),
-            ),
-            const CustomDividerWidget(),
+              const CustomDividerWidget(),
 
-            //Logout button
-            GestureDetector(
-              onTap: () {
-                ref.read(firebaseAuthServiceProvider).signOut();
-              },
-              child: const ListTile(
-                leading: Icon(Icons.logout),
-                title: Text(
-                  "로그아웃",
-                  style: TextStyle(fontSize: 20),
-                ),
-              ),
-            ),
-
-            //Logout button
-            GestureDetector(
-              onTap: () async {
-                try {
-                  final re = await engine.deleteAccount();
-                  debugPrint(re.toString());
-                  if (context.mounted) {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(
-                        content: Text('회원탈퇴가 완료되었습니다.'),
-                      ),
-                    );
-                  }
+              //Logout button
+              GestureDetector(
+                onTap: () {
                   ref.read(firebaseAuthServiceProvider).signOut();
-                } on FirebaseFunctionsException catch (e) {
-                  if (context.mounted) {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        content: Text('Error: ${e.code}/${e.message}'),
-                      ),
-                    );
-                  }
-                } catch (e) {
-                  if (context.mounted) {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        content: Text(
-                            'Error: $e'), // e.code: internal, e.message: INTERNAL
-                      ),
-                    );
-                  }
-                }
-              },
-              child: const Expanded(
-                  child: ListTile(
-                leading: Icon(Icons.person_off),
-                title: Text(
-                  "회원탈퇴",
-                  style: TextStyle(fontSize: 20),
+                },
+                child: const ListTile(
+                  leading: Icon(Icons.logout),
+                  title: Text(
+                    "로그아웃",
+                    style: TextStyle(fontSize: 20),
+                  ),
                 ),
-              )),
-            ),
-          ],
+              ),
+
+              //Logout button
+              GestureDetector(
+                onTap: () async {
+                  try {
+                    final re = await engine.deleteAccount();
+                    debugPrint(re.toString());
+                    if (context.mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text('회원탈퇴가 완료되었습니다.'),
+                        ),
+                      );
+                    }
+                    ref.read(firebaseAuthServiceProvider).signOut();
+                  } on FirebaseFunctionsException catch (e) {
+                    if (context.mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text('Error: ${e.code}/${e.message}'),
+                        ),
+                      );
+                    }
+                  } catch (e) {
+                    if (context.mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text(
+                              'Error: $e'), // e.code: internal, e.message: INTERNAL
+                        ),
+                      );
+                    }
+                  }
+                },
+                child: const Expanded(
+                    child: ListTile(
+                  leading: Icon(Icons.person_off),
+                  title: Text(
+                    "회원탈퇴",
+                    style: TextStyle(fontSize: 20),
+                  ),
+                )),
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -324,4 +323,3 @@ Widget _uploadProfileImageButtons(FirestoreService firestoreService,
     icon: const Icon(Icons.settings),
   );
 }
-

--- a/lib/utils/AppStrings.dart
+++ b/lib/utils/AppStrings.dart
@@ -1,6 +1,12 @@
 class AppStrings {
   static const String appTitle = '블루베리 플러터 템플릿';
 
+  //NickNameTextWidget.dart
+  static const String nickNameTextWidgetdefaultNickName = '닉네임';
+  static const String nickNameTextWidgetError = '오류';
+
+
+
   //MyPageScreen.dart
   static const String myPageTitle = '내 페이지';
   static const String loginButtonText = '로그인';

--- a/lib/utils/AppStrings.dart
+++ b/lib/utils/AppStrings.dart
@@ -1,17 +1,7 @@
 class AppStrings {
   static const String appTitle = '블루베리 플러터 템플릿';
 
-  //ChatPage.dart
-  static const String lessonChatScreenTitle = '채팅';
-
-  //ShoppingPageSample.dart
-  static const String shoppingPageTitle = '쇼핑 페이지';
-  static const String shoppingPageTitle1 = '이 제품들을 찾고 있나요?';
-  static const String shoppingPageSubTitle1 = '항상 최고의 블루베리를 찾아드립니다.';
-  static const String shoppingPageTitle2 = '신상품';
-  static const String shoppingPageSubTitle2 = '최신 제품을 확인하세요.';
-
-  //DeleteMyPage.dart
+  //MyPageScreen.dart
   static const String myPageTitle = '내 페이지';
   static const String loginButtonText = '로그인';
   static const String logoutButtonText = '로그아웃';
@@ -21,6 +11,15 @@ class AppStrings {
   static const String okButtonText = '확인';
   static const String loggedInMessage = '로그인 되었습니다.';
   static const String passwordForgot = '비밀번호를 잊어버렸나요?';
+  //ChatPage.dart
+  static const String lessonChatScreenTitle = '채팅';
+
+  //ShoppingPageSample.dart
+  static const String shoppingPageTitle = '쇼핑 페이지';
+  static const String shoppingPageTitle1 = '이 제품들을 찾고 있나요?';
+  static const String shoppingPageSubTitle1 = '항상 최고의 블루베리를 찾아드립니다.';
+  static const String shoppingPageTitle2 = '신상품';
+  static const String shoppingPageSubTitle2 = '최신 제품을 확인하세요.';
 
   //SignUpDialog.dart
   static const String signUpPageTitle = '회원가입';

--- a/lib/widgets/NickNameTextWidget.dart
+++ b/lib/widgets/NickNameTextWidget.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../providers/MyPageNameProvider.dart';
+
+class NickNameTextWidget extends ConsumerWidget {
+  const NickNameTextWidget({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final nickname = ref.watch(myPageNicknameProvider);
+    return nickname.when(
+      data: (name) => Text(
+        name,
+        style: const TextStyle(
+            fontSize: 20, fontWeight: FontWeight.bold),
+      ),
+      loading: () => Text(''),
+      error: (e, s) => const Text('Error'),
+    ),
+  }
+}

--- a/lib/widgets/NickNameTextWidget.dart
+++ b/lib/widgets/NickNameTextWidget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../providers/MyPageNameProvider.dart';
+import '../utils/AppStrings.dart';
 
 class NickNameTextWidget extends ConsumerWidget {
   const NickNameTextWidget({super.key});
@@ -15,7 +16,7 @@ class NickNameTextWidget extends ConsumerWidget {
         style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
       ),
       loading: () => Text(''),
-      error: (e, s) => const Text('Error'),
+      error: (e, s) => const Text(AppStrings.nickNameTextWidgetError),
     );
   }
 }

--- a/lib/widgets/NickNameTextWidget.dart
+++ b/lib/widgets/NickNameTextWidget.dart
@@ -12,11 +12,10 @@ class NickNameTextWidget extends ConsumerWidget {
     return nickname.when(
       data: (name) => Text(
         name,
-        style: const TextStyle(
-            fontSize: 20, fontWeight: FontWeight.bold),
+        style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
       ),
       loading: () => Text(''),
       error: (e, s) => const Text('Error'),
-    ),
+    );
   }
 }


### PR DESCRIPTION
## 설명
닉네임 프로바이더 + 닉네임 위젯 생성

## 변경 사항

- 서버에서 유저의 닉네임을 불러오는 로직을 추가했습니다.

## 체크리스트
< 체크리스트 항목을 확인해 주세요. >

- [x] 오늘도 행복하게 코딩했는가?
- [x] release 브랜치를 제대로 최신화 하고 이 브랜치에 merge 했는가?
- [x] PR 제목은 명확하고 간결한가?
- [x] PR 에는 하나의 작업에 대한 내용만 포함되었는가?
- [x] 파일명은 누구나 이해할 수 있게 작성되었는가?
- [x] camelCase를 사용하였는가? (ThisIsCamelCase, this_is_not_camel_case)
- [x] 텍스트는 AppStrings.dart 파일에서 가져오고 있는가?
- [x] 디스코드 채팅방에 완료된 태스크를 알렸는가?

## 스크린샷
< 여기에 이미지/동영상을 드래그 앤 드랍하면 링크가 생성됩니다. > 
<img alt="sample" width="240" src="https://github.com/user-attachments/assets/a8f5fa60-4f80-4dcb-be1d-053611d75549">

## 참조

관련된 이슈나 PR이 있다면 링크를 추가해주세요.
