### PR TITLE
pubspec dependencies에 필요없는 패키지 이동

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -71,20 +71,19 @@ dependencies:
   easy_engine: ^0.0.4
   cloud_functions: ^5.0.2
 
-  # Lint
-  flutter_lints: ^3.0.0
-
-  # Generate
-  flutter_gen: ^5.6.0
-  build_runner: ^2.4.11
-  json_serializable: ^6.8.0
-
   # Router
   go_router: ^14.2.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
+
+  # Generate
+  json_serializable: ^6.8.0
+  build_runner: ^2.4.11
+
+  # Lint
+  flutter_lints: ^3.0.0
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## 설명
pubspec dependencies에는 dependencies와 dev_dependencies가 있습니다. 

dependencies는 runtime에 필요한 패키지를 넣으시면 되고
dev_dependencies에는 개발과정에 필요한 패키지를 넣으시면 됩니다. 

dependencies에 추가된 패키지는 앱 용량에 관여하게되고 dev_dependenceis는 앱 용량에 관련이 없습니다.

패키지 설치 시 installing에 보면 dev에 설치해야하는지 아닌지가 적혀있습니다.

flutter_gen 같은 경우는 global로 설치했기 때문에 pubspec에 적을 필요 없습니다.
문서를 보니 pubspec에 추가하고 build_runner를 통해 생성하는 방법은 있는거같습니다.

## 변경 사항

- pubspec에 flutter_gen 제거
- json_serializable: ^6.8.0 => dev_dependencies로 이동
- build_runner: ^2.4.11 => dev_dependencies로 이동
- flutter_lints: ^3.0.0 => dev_dependencies로 이동

## 체크리스트
< 체크리스트 항목을 확인해 주세요. >

- [x] 오늘도 행복하게 코딩했는가?
- [x] release 브랜치를 제대로 최신화 하고 이 브랜치에 merge 했는가?
- [x] PR 제목은 명확하고 간결한가?
- [x] PR 에는 하나의 작업에 대한 내용만 포함되었는가?
- [x] 파일명은 누구나 이해할 수 있게 작성되었는가?
- [x] camelCase를 사용하였는가? (ThisIsCamelCase, this_is_not_camel_case)
- [x] 텍스트는 AppStrings.dart 파일에서 가져오고 있는가?
- [x] 디스코드 채팅방에 완료된 태스크를 알렸는가?

## 스크린샷

## 참조
<img width="805" alt="SCR-20240728-mkfw" src="https://github.com/user-attachments/assets/cd4f4f04-2327-48dd-935f-dfaa10f7a0fa">
