### PR TITLE
구글, 깃허브 소셜 로그인 코드 수정 | Makefile 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ lib/firebase_options.dart
 
 # vscode
 .vscode/launch.json
+
+# secret key
+sign_in_key.dart

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+ROOT := $(shell git rev-parse --show-toplevel)
+
+FLUTTER := $(shell which flutter)
+
+
+buildRunner:
+	@echo "❄️freezed build runner start"
+	@${FLUTTER} pub run build_runner build --delete-conflicting-outputs

--- a/lib/screens/mypage/LoginScreen.dart
+++ b/lib/screens/mypage/LoginScreen.dart
@@ -9,7 +9,6 @@ import '../../providers/user/UserInfoProvider.dart';
 import '../../services/SocialAuthService.dart';
 import '../../utils/AppStrings.dart';
 import '../../widgets/SquareTitleWidget.dart';
-import '../TopScreen.dart';
 import 'MyPageScreen.dart';
 import 'camera/ProfileCameraPage.dart';
 import 'camera/ProfileGalleryPage.dart';
@@ -25,6 +24,8 @@ import 'camera/ProfileGalleryPage.dart';
 final wantEditAgeProvider = StateProvider<bool>((ref) => false);
 final wantEditNameProvider = StateProvider<bool>((ref) => false);
 
+///# 로그인 화면
+///* 이메일, 소셜(구글,애플,깃허브) 로그인 기능 제공
 class LoginScreen extends ConsumerWidget {
   const LoginScreen({super.key});
 
@@ -178,21 +179,21 @@ Widget _buildLogin(BuildContext context, WidgetRef ref) {
             children: [
               //Google button
               SquareTileWidget(
-                  onTap: () => AuthService().signInWithGoogle(),
+                  onTap: () => SocialAuthService().signInWithGoogle(),
                   imagePath: 'assets/login_page_images/google.png'),
               const SizedBox(
                 width: 10,
               ),
               //Apple button
               SquareTileWidget(
-                  onTap: () => AuthService().signInWithApple(),
+                  onTap: () => SocialAuthService().signInWithApple(),
                   imagePath: 'assets/login_page_images/apple.png'),
               const SizedBox(
                 width: 10,
               ),
               //github button
               SquareTileWidget(
-                  onTap: () => AuthService().signInWithGithub(),
+                  onTap: () => SocialAuthService().signInWithGithub(),
                   imagePath: 'assets/login_page_images/github.png'),
             ],
           ),

--- a/lib/services/SocialAuthService.dart
+++ b/lib/services/SocialAuthService.dart
@@ -58,30 +58,12 @@ class SocialAuthService {
   }
 
   ///Github Sign In
-  Future<UserCredential> signInWithGithub() async {
+  Future<void> signInWithGithub() async {
     GithubAuthProvider githubAuthProvider = GithubAuthProvider();
-    return await FirebaseAuth.instance.signInWithProvider(githubAuthProvider);
-    // scopes: [
-    //   displayName : userCredential.user!.displayName!,
-    //   photoURL: userCredential.user!.photoURL ?? "",
-    //   email: userCredential.user!.email!,
-    // ],
+    final userCredential =
+        await FirebaseAuth.instance.signInWithProvider(githubAuthProvider);
 
-    // await FirebaseAuth.instance.signInWithCredential(credential);
-    // var ref = FirebaseFirestore.instance.collection('users').doc(FirebaseAuth.instance.currentUser!.uid);
-    // var snapshot = await ref.get();
-    // if(!snapshot.exists){
-    //   return await FirebaseFirestore.instance.collection('users').doc(FirebaseAuth.instance.currentUser!.uid).set({
-    //     'account_level' : 1,
-    //     //account_level이 0이되면 Delete timestamp확인하여 14일 뒤 삭제
-    //     'email' : FirebaseAuth.instance.currentUser!.email,
-    //     'name' : FirebaseAuth.instance.currentUser!.displayName,
-    //     'age' : 0,
-    //     'createdAt' : DateTime.timestamp(),
-    //     'profilePicture' : "",
-    //   }
-    //   );
-    // }
+    getAuthenticateWithFirebase(userCredential);
   }
 
   ///* 인증정보를 바탕으로 firestore에 저장하는 함수

--- a/lib/services/SocialAuthService.dart
+++ b/lib/services/SocialAuthService.dart
@@ -3,35 +3,23 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 
-class AuthService {
+class SocialAuthService {
   get context => null;
 
-
   ///Google Sign In
-  signInWithGoogle() async {
-    final GoogleSignInAccount? gUser = await GoogleSignIn().signIn();
-
-    final GoogleSignInAuthentication gAuth = await gUser!.authentication;
-
-    final credential = GoogleAuthProvider.credential(
-      accessToken: gAuth.accessToken,
-      idToken: gAuth.idToken,
-    );
-
-    await FirebaseAuth.instance.signInWithCredential(credential);
-    var ref = FirebaseFirestore.instance.collection('users').doc(FirebaseAuth.instance.currentUser!.uid);
-    var snapshot = await ref.get();
-    if(!snapshot.exists){
-      return await FirebaseFirestore.instance.collection('users').doc(FirebaseAuth.instance.currentUser!.uid).set({
-        'account_level' : 1,
-        //account_level이 0이되면 Delete timestamp확인하여 14일 뒤 삭제
-        'email' : FirebaseAuth.instance.currentUser!.email,
-        'name' : FirebaseAuth.instance.currentUser!.displayName,
-        'age' : 0,
-        'createdAt' : DateTime.timestamp(),
-        'profilePicture' : "",
-      }
+  Future<void> signInWithGoogle() async {
+    ///* GoogleSignIn 객체 생성
+    final googleSignIn = GoogleSignIn();
+    final GoogleSignInAccount? gUser = await googleSignIn.signIn();
+    if (gUser != null) {
+      final GoogleSignInAuthentication gAuth = await gUser.authentication;
+      final gCredential = GoogleAuthProvider.credential(
+        accessToken: gAuth.accessToken,
+        idToken: gAuth.idToken,
       );
+      final userCredential =
+          await FirebaseAuth.instance.signInWithCredential(gCredential);
+      getAuthenticateWithFirebase(userCredential);
     }
   }
 
@@ -49,24 +37,28 @@ class AuthService {
       accessToken: appleIdCredential.authorizationCode,
     );
     await FirebaseAuth.instance.signInWithCredential(credential);
-    var ref = FirebaseFirestore.instance.collection('users').doc(FirebaseAuth.instance.currentUser!.uid);
+    var ref = FirebaseFirestore.instance
+        .collection('users')
+        .doc(FirebaseAuth.instance.currentUser!.uid);
     var snapshot = await ref.get();
-    if(!snapshot.exists){
-      return await FirebaseFirestore.instance.collection('users').doc(FirebaseAuth.instance.currentUser!.uid).set({
-        'account_level' : 1,
+    if (!snapshot.exists) {
+      return await FirebaseFirestore.instance
+          .collection('users')
+          .doc(FirebaseAuth.instance.currentUser!.uid)
+          .set({
+        'account_level': 1,
         //account_level이 0이되면 Delete timestamp확인하여 14일 뒤 삭제
-        'email' : FirebaseAuth.instance.currentUser!.email,
-        'name' : FirebaseAuth.instance.currentUser!.displayName,
-        'age' : 0,
-        'createdAt' : DateTime.timestamp(),
-        'profilePicture' : "",
-      }
-      );
+        'email': FirebaseAuth.instance.currentUser!.email,
+        'name': FirebaseAuth.instance.currentUser!.displayName,
+        'age': 0,
+        'createdAt': DateTime.timestamp(),
+        'profilePicture': "",
+      });
     }
   }
 
   ///Github Sign In
-  Future<UserCredential>signInWithGithub() async{
+  Future<UserCredential> signInWithGithub() async {
     GithubAuthProvider githubAuthProvider = GithubAuthProvider();
     return await FirebaseAuth.instance.signInWithProvider(githubAuthProvider);
     // scopes: [
@@ -90,9 +82,30 @@ class AuthService {
     //   }
     //   );
     // }
-
   }
 
-
+  ///* 인증정보를 바탕으로 firestore에 저장하는 함수
+  void getAuthenticateWithFirebase(UserCredential? credential) async {
+    if (credential?.user == null) {
+      return null;
+    }
+    var ref = FirebaseFirestore.instance
+        .collection('users')
+        .doc(FirebaseAuth.instance.currentUser!.uid);
+    var snapshot = await ref.get();
+    if (!snapshot.exists) {
+      return await FirebaseFirestore.instance
+          .collection('users')
+          .doc(FirebaseAuth.instance.currentUser!.uid)
+          .set({
+        'account_level': 1,
+        //account_level이 0이되면 Delete timestamp확인하여 14일 뒤 삭제
+        'email': FirebaseAuth.instance.currentUser!.email,
+        'name': FirebaseAuth.instance.currentUser!.displayName,
+        'age': 0,
+        'createdAt': DateTime.timestamp(),
+        'profilePicture': "",
+      });
+    }
+  }
 }
-


### PR DESCRIPTION
## 설명
 - 소셜로그인(구글, 깃허브) 기능 버그 수정
 - Makefile 추가

## 변경 사항
- 구글, 깃허브 로그인 관련 코드 수정 + 로컬에서 IOS,Android 세팅 수정(추후 문서화,파일 정리후 공유필요)
  - 구글; redirectUrl, clientId 설정이 누락되어 PlatformException으로 강제종료되는 현상 발생했던 버그를 수정함
  - 깃허브; IOS의 경우 URL [type 설정](https://firebase.google.com/docs/auth/ios/github-auth?_gl=1*q5miz6*_up*MQ..*_ga*NzYwMDQwMjc1LjE3MjIxNDQzNDM.*_ga_CW55HF8NVT*MTcyMjE0NDM0My4xLjAuMTcyMjE0NDM0My4wLjAuMA..#handle_the_sign-in_flow_with_the_firebase_sdk)이 누락되어 PlatformException 버그 수정
- Makefile 추가; buildRunner,추후 배포시 앱 빌드등 간편한 명령어 실행툴 추가
## 체크리스트
< 체크리스트 항목을 확인해 주세요. >

- [x] 오늘도 행복하게 코딩했는가?
- [x] release 브랜치를 제대로 최신화 하고 이 브랜치에 merge 했는가?
- [x] PR 제목은 명확하고 간결한가?
- [x] PR 에는 하나의 작업에 대한 내용만 포함되었는가?
- [x] 파일명은 누구나 이해할 수 있게 작성되었는가?
- [x] camelCase를 사용하였는가? (ThisIsCamelCase, this_is_not_camel_case)
- [x] 텍스트는 AppStrings.dart 파일에서 가져오고 있는가?
- [x] 디스코드 채팅방에 완료된 태스크를 알렸는가?

## 스크린샷
< 여기에 이미지/동영상을 드래그 앤 드랍하면 링크가 생성됩니다. > 
<img alt="sample" width="240" src="https://github.com/user-attachments/assets/8a50972e-e908-4c2a-be57-5a821943c3b7">

## 참조
- Makefile의 경우, 할당된 테스크가 아니지만 개인적으로 운용하기 위해 추가한 툴입니다. 혹시 해당 프로젝트의 방향성에 맞지 않다면 제외하여 다시 커밋 올리겠습니다:)
- 마이페이지에서 로그인 방식(구글,소셜,이메일등)이 하드코딩 되어있어 해당 부분 수정이 필요할 것 같습니다!
해당 작업자가 없다면 애플로그인까지 완료한 이후 제가 작업하겠습니다:)
