### PR TITLE
feat 매치 페이지 provider 연결 및 위젯 분리

### DIFF
--- a/lib/providers/match/DogProfileProvider.dart
+++ b/lib/providers/match/DogProfileProvider.dart
@@ -1,0 +1,9 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../model/DogProfileModel.dart';
+
+final dogProfilesProvider = FutureProvider((ref) async {
+  final firestore = FirebaseFirestore.instance;
+  final snapshot = await firestore.collection('dogProfiles').get();
+  return snapshot.docs.map((doc) => DogProfileModel.fromJson(doc.data())).toList();
+});

--- a/lib/screens/match/MatchScreen.dart
+++ b/lib/screens/match/MatchScreen.dart
@@ -1,112 +1,26 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_card_swiper/flutter_card_swiper.dart';
+import '../../utils/AppStrings.dart';
+import '../../widgets/match/MatchProfileListWidget.dart';
 
-import '../../model/DogProfileModel.dart';
-import '../../widgets/match/SwiperCardWidget.dart';
-import 'ProfileScreen.dart';
-
-///  MatchPage - 프로필 스와이프 매칭 화면
+///  MatchScreen - 프로필 스와이프 매칭 화면
 ///
 ///  주요 구성 요소:
-///  - CardSwiper: 프로필 카드를 스와이프할 수 있는 메인 위젯
-///  - FloatingActionButton: 수동으로 좌/우 스와이프를 할 수 있는 버튼
+///  - SwipeCardWidget: 프로필 카드를 스와이프할 수 있는 위젯
+///  - SwipeButtonWidget: 수동으로 좌/우 스와이프를 할 수 있는 버튼
 
-
-final List<DogProfileModel> dogProfiles = [
-  const DogProfileModel(
-    name: '멍멍이',
-    gender: '수컷',
-    breed: '골든 리트리버',
-    location: '서울',
-    bio: '산책을 좋아하는 활발한 강아지예요!',
-    imageUrl: 'https://img1.daumcdn.net/thumb/R800x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FcY8RCd%2FbtsC31gfzPL%2FbSnADONPu66xPesaWHmW00%2Fimg.jpg',
-  ),
-  const DogProfileModel(
-    name: '뭉치',
-    gender: '암컷',
-    breed: '푸들',
-    location: '부산',
-    bio: '애교 많고 사랑스러운 강아지입니다.',
-    imageUrl: 'https://image.dongascience.com/Photo/2017/07/14994185580021.jpg',
-  ),
-  const DogProfileModel(
-    name: '초코',
-    gender: '수컷',
-    breed: '비글',
-    location: '대구',
-    bio: '장난기 많고 활발한 성격이에요.',
-    imageUrl: 'https://cdn.newscj.com/news/photo/201309/170126_122268_2013.jpg',
-  ),
-];
-
-class MatchScreen extends StatefulWidget {
+class MatchScreen extends StatelessWidget {
   const MatchScreen({super.key});
-
-  @override
-  State<MatchScreen> createState() => _MatchScreenState();
-}
-
-class _MatchScreenState extends State<MatchScreen> {
-  final CardSwiperController controller = CardSwiperController();
-  final cards = dogProfiles.map(SwiperCardWidget.new).toList();
-
-  @override
-  void dispose() {
-    controller.dispose();
-    super.dispose();
-  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: SafeArea(
-        child: Column(
-          children: [
-            Flexible(
-              child: CardSwiper(
-                controller: controller,
-                cardsCount: cards.length,
-                onSwipe: _onSwipe,
-                cardBuilder: (
-                  context,
-                  index,
-                  horizontalThresholdPercentage,
-                  verticalThresholdPercentage,
-                ) =>
-                    cards[index],
-              ),
-            ),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: [
-                FloatingActionButton(
-                  heroTag: '0',
-                  onPressed: () => controller.swipe(CardSwiperDirection.left),
-                  child: const Icon(Icons.close),
-                ),
-                FloatingActionButton(
-                  heroTag: '1',
-                  onPressed: () => controller.swipe(CardSwiperDirection.right),
-                  child: const Icon(Icons.check),
-                ),
-              ],
-            ),
-          ],
+      appBar: AppBar(title: const Text(AppStrings.matchScreenTitle)),
+      body: const Padding(
+        padding: EdgeInsets.only(bottom: 36.0),
+        child: Center(
+          child: MatchProfileListWidget(),
         ),
       ),
     );
-  }
-
-  bool _onSwipe(
-      int previousIndex, int? currentIndex, CardSwiperDirection direction) {
-    if (direction == CardSwiperDirection.right) {
-      Navigator.of(context).push(
-        MaterialPageRoute(
-          builder: (context) =>
-              ProfileScreen(dogProfile: dogProfiles[previousIndex]),
-        ),
-      );
-    }
-    return true;
   }
 }

--- a/lib/screens/match/ProfileScreen.dart
+++ b/lib/screens/match/ProfileScreen.dart
@@ -1,3 +1,4 @@
+import 'package:blueberry_flutter_template/utils/AppTextStyle.dart';
 import 'package:flutter/material.dart';
 
 import '../../model/DogProfileModel.dart';
@@ -30,7 +31,7 @@ class ProfileScreen extends StatelessWidget {
                 children: [
                   Text(
                     dogProfile.name,
-                    style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+                    style: black16BoldTextStyle,
                   ),
                   const SizedBox(height: 8),
                   Text('성별: ${dogProfile.gender}'),
@@ -39,7 +40,7 @@ class ProfileScreen extends StatelessWidget {
                   const SizedBox(height: 16),
                   const Text(
                     '소개',
-                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                    style: black16BoldTextStyle,
                   ),
                   Text(dogProfile.bio),
                 ],

--- a/lib/utils/AppStrings.dart
+++ b/lib/utils/AppStrings.dart
@@ -20,6 +20,9 @@ class AppStrings {
   //ChatPage.dart
   static const String lessonChatScreenTitle = '채팅';
 
+  //MatchScreen.dart
+  static const String matchScreenTitle = '매칭';
+
   //ShoppingPageSample.dart
   static const String shoppingPageTitle = '쇼핑 페이지';
   static const String shoppingPageTitle1 = '이 제품들을 찾고 있나요?';

--- a/lib/utils/AppTextStyle.dart
+++ b/lib/utils/AppTextStyle.dart
@@ -83,11 +83,17 @@ const TextStyle blue16TextStyle = TextStyle(
 );
 
 // ---------------white---------------- //
-const TextStyle white12BoldTextStyle = TextStyle(
+const TextStyle white24TextStyle = TextStyle(
+  fontWeight: FontWeight.normal,
+  fontStyle: FontStyle.normal,
+  color: white,
+  fontSize: 24,
+);
+const TextStyle white24BoldTextStyle = TextStyle(
   fontWeight: FontWeight.bold,
   fontStyle: FontStyle.normal,
   color: white,
-  fontSize: 12,
+  fontSize: 24,
 );
 
 const TextStyle white16TextStyle = TextStyle(
@@ -105,6 +111,13 @@ const TextStyle white16BoldTextStyle = TextStyle(
 
 const TextStyle white12TextStyle = TextStyle(
   fontWeight: FontWeight.normal,
+  fontStyle: FontStyle.normal,
+  color: white,
+  fontSize: 12,
+);
+
+const TextStyle white12BoldTextStyle = TextStyle(
+  fontWeight: FontWeight.bold,
   fontStyle: FontStyle.normal,
   color: white,
   fontSize: 12,

--- a/lib/widgets/match/MatchProfileListWidget.dart
+++ b/lib/widgets/match/MatchProfileListWidget.dart
@@ -1,0 +1,60 @@
+import 'package:blueberry_flutter_template/model/DogProfileModel.dart';
+import 'package:blueberry_flutter_template/widgets/match/SwipeButtonWidget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_card_swiper/flutter_card_swiper.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../providers/match/DogProfileProvider.dart';
+import '../../screens/match/ProfileScreen.dart';
+import 'SwipeCardWidget.dart';
+
+/// MatchProfileListWidget - 메인 위젯으로, SwipeCard, SwipeButton와 CardSwiperController을 통해 매칭 기능을 구현함
+
+class MatchProfileListWidget extends ConsumerWidget {
+  const MatchProfileListWidget({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final list = ref.watch(dogProfilesProvider);
+
+    return list.when(
+      data: (data) => _buildCardView(context, ref, data),
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (error, stackTrace) => Center(child: Text('Error: $error')),
+    );
+  }
+}
+
+Widget _buildCardView(BuildContext context, WidgetRef ref, List<DogProfileModel> data) {
+  final cardSwiperController = CardSwiperController();
+  final cards = data.map(SwipeCardWidget.new).toList();
+
+  return Column(
+    children: [
+      Flexible(
+        child: CardSwiper(
+          controller: cardSwiperController,
+          cardsCount: cards.length,
+          onSwipe: (previousIndex, currentIndex, direction) {
+            if (direction == CardSwiperDirection.right) {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => ProfileScreen(dogProfile: data[previousIndex]),
+                ),
+              );
+            }
+            return true;
+          },
+          cardBuilder: (context, index, horizontalThresholdPercentage, verticalThresholdPercentage,) => cards[index],
+        ),
+      ),
+      Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: [
+          SwipeButtonWidget(onPressed: () => cardSwiperController.swipe(CardSwiperDirection.left), icon: Icons.close),
+          SwipeButtonWidget(onPressed: () => cardSwiperController.swipe(CardSwiperDirection.right), icon: Icons.check),
+        ],
+      ),
+    ],
+  );
+}

--- a/lib/widgets/match/SwipeButtonWidget.dart
+++ b/lib/widgets/match/SwipeButtonWidget.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+///  MatchScreen - 수동으로 좌/우 스와이프를 할 수 있는 버튼
+///
+/// 추후 디자인이 들어갈 수 있기에 따로 빼놨음
+
+class SwipeButtonWidget extends StatelessWidget {
+  final VoidCallback onPressed;
+  final IconData icon;
+
+  const SwipeButtonWidget({
+    super.key,
+    required this.onPressed,
+    required this.icon,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return FloatingActionButton(
+      heroTag: UniqueKey(),
+      onPressed: onPressed,
+      child: Icon(icon),
+      // 여기에 커스텀 스타일 추가
+    );
+  }
+}

--- a/lib/widgets/match/SwipeCardWidget.dart
+++ b/lib/widgets/match/SwipeCardWidget.dart
@@ -1,11 +1,15 @@
 import 'package:flutter/material.dart';
 
 import '../../model/DogProfileModel.dart';
+import '../../utils/AppColors.dart';
+import '../../utils/AppTextStyle.dart';
 
-class SwiperCardWidget extends StatelessWidget {
+/// SwipeCardWidget - 프로필 카드를 스와이프할 수 있는 위젯
+
+class SwipeCardWidget extends StatelessWidget {
   final DogProfileModel dogProfiles;
 
-  const SwiperCardWidget(
+  const SwipeCardWidget(
     this.dogProfiles, {
     super.key,
   });
@@ -34,12 +38,11 @@ class SwiperCardWidget extends StatelessWidget {
             gradient: LinearGradient(
               begin: Alignment.bottomCenter,
               end: Alignment.topCenter,
-              colors: [Colors.black.withOpacity(0.8), Colors.transparent],
+              colors: [richBlack.withOpacity(0.8), richBlack.withOpacity(0)],
             ),
           ),
           child: Padding(
-            padding: EdgeInsets.symmetric(
-                vertical: height * 0.03, horizontal: width * 0.05),
+            padding: EdgeInsets.symmetric(vertical: height * 0.03, horizontal: width * 0.05),
             child: Column(
               mainAxisAlignment: MainAxisAlignment.end,
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -48,26 +51,19 @@ class SwiperCardWidget extends StatelessWidget {
                   children: [
                     Text(
                       dogProfiles.name,
-                      style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                            color: Colors.white,
-                            fontWeight: FontWeight.bold,
-                          ),
+                      style: white24BoldTextStyle,
                     ),
                     SizedBox(width: width * 0.02),
                     Text(
                       '${dogProfiles.gender} • ${dogProfiles.breed} • ${dogProfiles.location}',
-                      style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                            color: Colors.white70,
-                          ),
+                      style: white16TextStyle,
                     ),
                   ],
                 ),
                 SizedBox(height: height * 0.005),
                 Text(
                   dogProfiles.bio,
-                  style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                        color: Colors.white70,
-                      ),
+                  style: white16TextStyle,
                 ),
               ],
             ),


### PR DESCRIPTION
## 설명
기존의 `MatchScreen` 에서 더미데이터를 firestore로 옮겨서 provider을 통해 데이터를 받을 수 있도록 수정하였습니다. 또한, 위젯 분리를 통해 StatefulWidget을 없애고 StatelessWidget, ConsumerWidget으로 구성할 수 있도록 수정하였습니다.
## 변경 사항

- 데이터 로딩을 위한 dogProfilesProvider 추가: firestore에 `dogProfiles` 생성
- Widget 분리: MatchProfileListWidget - SwipeButtonWidget - SwipeCardWidget

## 체크리스트
< 체크리스트 항목을 확인해 주세요. >

- [x] 오늘도 행복하게 코딩했는가?
- [x] release 브랜치를 제대로 최신화 하고 이 브랜치에 merge 했는가?
- [x] PR 제목은 명확하고 간결한가?
- [x] PR 에는 하나의 작업에 대한 내용만 포함되었는가?
- [x] 파일명은 누구나 이해할 수 있게 작성되었는가?
- [x] camelCase를 사용하였는가? (ThisIsCamelCase, this_is_not_camel_case)
- [x] 텍스트는 AppStrings.dart 파일에서 가져오고 있는가?
- [x] 디스코드 채팅방에 완료된 태스크를 알렸는가?

## 스크린샷
<img width="350" alt="image" src="https://github.com/user-attachments/assets/11400f45-5334-4c58-b4af-0859c4df23b6">

