### PR TITLE
🐛 bug: 유저모델 및 ranking list 누락 수정

### DIFF
--- a/lib/providers/rank/UserRankProvider.dart
+++ b/lib/providers/rank/UserRankProvider.dart
@@ -75,12 +75,15 @@ Future<List<UserModel>> _fetchUsersFromFirestore() async {
       if (doc.exists) {
         final data = doc.data()!;
         return UserModel(
+          userClass: data['userClass'] as String,
           userId: doc.id,
           name: data['name'] as String,
           email: data['email'] as String,
           age: data['age'] as int,
-          profileImageUrl: data['profilePicture'] as String,
+          isMemberShip: data['isMemberShip'] as bool,
+          profileImageUrl: data['profilePicture'] as String?,
           createdAt: DateTime.parse(data['createdAt'] as String),
+          fcmToken: data['fcmToken'] as String?,
         );
       } else {
         throw Exception('User not found');

--- a/lib/widgets/rank/RankViewWidget.dart
+++ b/lib/widgets/rank/RankViewWidget.dart
@@ -1,17 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:blueberry_flutter_template/utils/AppTextStyle.dart';
 import 'package:blueberry_flutter_template/model/UserModel.dart';
 import 'package:blueberry_flutter_template/providers/rank/UserRankProvider.dart';
 import 'package:blueberry_flutter_template/utils/AppStrings.dart';
-import 'package:blueberry_flutter_template/widgets/rank/UserRankingTile.dart';
 
 class RankViewWidget extends ConsumerWidget {
   const RankViewWidget({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final userAsyncValue = ref.watch(userProvider);
+    final userRankings = ref.watch(userProvider);
 
     return Scaffold(
       appBar: AppBar(
@@ -23,27 +23,27 @@ class RankViewWidget extends ConsumerWidget {
           // ignore: unused_result
           await ref.refresh(userProvider.future);
         },
-        child: _buildBody(userAsyncValue),
+        child: buildBody(userRankings),
       ),
     );
   }
 
-  Widget _buildBody(AsyncValue<List<UserModel>> userAsyncValue) {
-    return userAsyncValue.when(
-      data: (users) => _buildUserList(users),
+  Widget buildBody(AsyncValue<List<UserModel>> userRankings) {
+    return userRankings.when(
+      data: (users) => buildUserList(users),
       loading: () => const Center(child: CircularProgressIndicator()),
       error: (error, stack) => Center(child: Text('Error: $error')),
     );
   }
 
-  Widget _buildUserList(List<UserModel> users) {
+  Widget buildUserList(List<UserModel> users) {
     return CustomScrollView(
       slivers: [
         SliverList(
           delegate: SliverChildBuilderDelegate(
             (context, index) {
               final user = users[index];
-              return UserRankingTile(
+              return userRankingList(
                 rank: index + 1,
                 userName: user.name,
               );
@@ -52,6 +52,22 @@ class RankViewWidget extends ConsumerWidget {
           ),
         ),
       ],
+    );
+  }
+
+  Widget userRankingList({
+    required int rank,
+    required String userName,
+  }) {
+    return ListTile(
+      leading: Text(
+        '$rank',
+        style: black16TextStyle,
+      ),
+      title: Text(
+        userName,
+        style: black16TextStyle,
+      ),
     );
   }
 }


### PR DESCRIPTION
## 설명

유저모델 변경 반영 및 랭킹 리스트 타일이 누락되어 생기는 버그를 수정했습니다.

## 변경 사항

- 변경 1
파이어베이스에서 유저정보 가져와서 맵핑하는 과정에서 유저모델에 빠진 프로퍼티를 반영하여 수정했습니다.

- 변경 2
랭킹 페이지에서 list tile이 빠져있는 버그를 수정했습니다.

## 체크리스트

- [x] 오늘도 행복하게 코딩했는가?
- [x] release 브랜치를 제대로 최신화 하고 이 브랜치에 merge 했는가?
- [x] PR 제목은 명확하고 간결한가?
- [ ] PR 에는 하나의 작업에 대한 내용만 포함되었는가?
- [x] 파일명은 누구나 이해할 수 있게 작성되었는가?
- [x] camelCase를 사용하였는가? (ThisIsCamelCase, this_is_not_camel_case)
- [x] 텍스트는 AppStrings.dart 파일에서 가져오고 있는가?
- [x] 디스코드 채팅방에 완료된 태스크를 알렸는가?

## 스크린샷

<img src="https://github.com/user-attachments/assets/f511e0b8-8e3d-4f87-afe9-1a46cd770d94" width="250">


## 참조

관련된 이슈나 PR이 있다면 링크를 추가해주세요.
