### PR TITLE
[ Feat ] 애플로그인 로직 정리,회원탈퇴 기능 구현 추가 , README 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ Storage > 시작하기 > 테스트 모드에서 시작
 WEB IMAGE RENDERING (https://docs.flutter.dev/development/platform-integration/web/renderers)
 - `flutter run -d chrome --web-renderer html`
 
+로그인 기능(구글,애플,깃허브)를 이용하기 위해서 각 서비스의 키 설정이 필요합니다.
+- 자세한 설명은 깃허브 위키를 참고해주세요.
+- ![깃허브 위키](https://github.com/blueberry-team/blueberry_template/wiki/%EC%86%8C%EC%85%9C-%EB%A1%9C%EA%B7%B8%EC%9D%B8-Native,-Console-%EC%84%A4%EC%A0%95-%EB%B0%A9%EB%B2%95)
+
+
 ## 템플릿 기반 서비스 오픈 계획
 
 ![image](https://github.com/jwson-automation/blueberry_template/assets/108061510/e451dfde-9141-42a5-805c-a0062a9c11e2)

--- a/lib/services/SocialAuthService.dart
+++ b/lib/services/SocialAuthService.dart
@@ -1,5 +1,10 @@
+import 'dart:convert';
+import 'dart:math';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:crypto/crypto.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/services.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 
@@ -24,38 +29,42 @@ class SocialAuthService {
   }
 
   ///Apple Sign In
-  signInWithApple() async {
-    final appleIdCredential = await SignInWithApple.getAppleIDCredential(
-      scopes: [
-        AppleIDAuthorizationScopes.email,
-        AppleIDAuthorizationScopes.fullName,
-      ],
-    );
-    final oAuthProvider = OAuthProvider('apple.com');
-    final credential = oAuthProvider.credential(
+  void signInWithApple() async {
+    final rawNonce = generateNonce();
+    final nonce = sha256ofString(rawNonce);
+
+    late final AuthorizationCredentialAppleID appleIdCredential;
+    await SignInWithApple.getAppleIDCredential(scopes: [
+      AppleIDAuthorizationScopes.email,
+      AppleIDAuthorizationScopes.fullName,
+    ], nonce: nonce)
+        .then((value) {
+      appleIdCredential = value;
+    }).onError((error, stackTrace) {
+      if (error is PlatformException) return;
+    });
+
+    final credential = OAuthProvider('apple.com').credential(
       idToken: appleIdCredential.identityToken,
       accessToken: appleIdCredential.authorizationCode,
+      rawNonce: rawNonce,
     );
-    await FirebaseAuth.instance.signInWithCredential(credential);
-    var ref = FirebaseFirestore.instance
-        .collection('users')
-        .doc(FirebaseAuth.instance.currentUser!.uid);
-    var snapshot = await ref.get();
-    if (!snapshot.exists) {
-      return await FirebaseFirestore.instance
-          .collection('users')
-          .doc(FirebaseAuth.instance.currentUser!.uid)
-          .set({
-        'account_level': 1,
-        //account_level이 0이되면 Delete timestamp확인하여 14일 뒤 삭제
-        'email': FirebaseAuth.instance.currentUser!.email,
-        'name': FirebaseAuth.instance.currentUser!.displayName,
-        'age': 0,
-        'isMemberShip': false,
-        'createdAt': DateTime.timestamp(),
-        'profilePicture': "",
-      });
-    }
+    var result = await FirebaseAuth.instance.signInWithCredential(credential);
+    getAuthenticateWithFirebase(result);
+  }
+
+  String generateNonce([int length = 32]) {
+    final charset =
+        '0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._';
+    final random = Random.secure();
+    return List.generate(length, (_) => charset[random.nextInt(charset.length)])
+        .join();
+  }
+
+  String sha256ofString(String input) {
+    final bytes = utf8.encode(input);
+    final digest = sha256.convert(bytes);
+    return digest.toString();
   }
 
   ///Github Sign In
@@ -63,7 +72,6 @@ class SocialAuthService {
     GithubAuthProvider githubAuthProvider = GithubAuthProvider();
     final userCredential =
         await FirebaseAuth.instance.signInWithProvider(githubAuthProvider);
-
     getAuthenticateWithFirebase(userCredential);
   }
 
@@ -86,7 +94,6 @@ class SocialAuthService {
         'email': FirebaseAuth.instance.currentUser!.email,
         'name': FirebaseAuth.instance.currentUser!.displayName,
         'age': 0,
-        'isMemberShip': false,
         'createdAt': DateTime.timestamp(),
         'profilePicture': "",
       });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -74,6 +74,7 @@ dependencies:
 
   # Router
   go_router: ^14.2.1
+  crypto: ^3.0.3
 
   # In App Purchase
   in_app_purchase: ^3.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,11 @@ dependencies:
   photo_manager: ^3.2.0
   image_picker: ^1.1.0
   flutter_cache_manager: ^3.3.3
+  dart_jsonwebtoken: ^2.14.0
+  package_info_plus: ^8.0.0
+
+  # REST API Client
+  dio: ^5.5.0+1
 
   # Profile Upload
   camera: ^0.11.0+1
@@ -78,6 +83,7 @@ dependencies:
 
   # In App Purchase
   in_app_purchase: ^3.2.0
+
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 설명
- 애플로그인 로직 정리,회원탈퇴 기능 구현 추가
- 소셜 로그인 관련 세팅 필요 사항 README 추가

## 변경 사항

- 애플로그인 로직 정리(firestore 중복 로직 삭제)
- 애플로그인 회원탈퇴 기능 구현
  - 애플로그인의 경우 추가 로직이 필요하여, 해당사항 추가
- README 정리(위키에 정리하고 링크 첨부) 
  - [소셜로그인 관련 문서화 위키 ](https://github.com/blueberry-team/blueberry_template/wiki/%EC%86%8C%EC%85%9C-%EB%A1%9C%EA%B7%B8%EC%9D%B8-Native,-Console-%EC%84%A4%EC%A0%95-%EB%B0%A9%EB%B2%95)

## 체크리스트
< 체크리스트 항목을 확인해 주세요. >

- [x] 오늘도 행복하게 코딩했는가?
- [x] release 브랜치를 제대로 최신화 하고 이 브랜치에 merge 했는가?
- [x] PR 제목은 명확하고 간결한가?
- [x] PR 에는 하나의 작업에 대한 내용만 포함되었는가?
- [x] 파일명은 누구나 이해할 수 있게 작성되었는가?
- [x] camelCase를 사용하였는가? (ThisIsCamelCase, this_is_not_camel_case)
- [x] 텍스트는 AppStrings.dart 파일에서 가져오고 있는가?
- [x] 디스코드 채팅방에 완료된 태스크를 알렸는가?

## 스크린샷

## 참조
- 애플 로그인 계정 관련 설정이 필요해서 기능 구현 테스트는 하지 못했습니다! 계정 키 설정후에 테스트가 필요합니다

관련된 이슈나 PR이 있다면 링크를 추가해주세요.
