### PR TITLE
친구목록 페이지 레포지토리 이동 및 피드백 반영하여 개선

### DIFF
--- a/lib/feature/friend/provider/FriendsListProvider.dart
+++ b/lib/feature/friend/provider/FriendsListProvider.dart
@@ -15,15 +15,9 @@ final friendsListProvider = StreamProvider<List<FriendModel>>((ref) {
 
 // friendImageURL을 가져오는 함수
 Future<String> fetchFriendImageUrl(String imageName) async {
-  try {
-    final ref = FirebaseStorage.instance.ref('friends-profile/$imageName.jpeg');
+    final ref = FirebaseStorage.instance.ref('friends-profile/$imageName');
     final imageUrl = await ref.getDownloadURL();
-    print('프로바이더 패치 함수: $imageUrl'); // 로깅 추가
     return imageUrl;
-  } catch (e) {
-    print('Error fetching image URL: $e');
-    return '';
-  }
 }
 
 // 이미지 URL을 제공하는 Provider

--- a/lib/feature/friend/provider/FriendsListProvider.dart
+++ b/lib/feature/friend/provider/FriendsListProvider.dart
@@ -4,30 +4,42 @@ import 'package:firebase_storage/firebase_storage.dart';
 
 import '../../../model/FriendModel.dart';
 
+
+// 친구 목록을 제공하는 Provider
 final friendsListProvider = StreamProvider<List<FriendModel>>((ref) {
   final firestore = FirebaseFirestore.instance;
   return firestore.collection('friends').snapshots().map((snapshot) {
-    return snapshot.docs.map((doc) {
-      final data = doc.data();
-      return FriendModel(
-        userId: data['userId'] as String,
-        friendId: data['friendId'] as String,
-        name: data['name'] as String,
-        imageUrl: data['imageUrl'] as String,
-        status: data['status'] as String,
-        likes: data['likes'] as int,
-        lastConnect: (data['lastConnect'] as Timestamp).toDate(),
-      );
-    }).toList();
+    return snapshot.docs.map((doc) => FriendModel.fromDocument(doc)).toList();
   });
 });
 
+// friendImageURL을 가져오는 함수
 Future<String> fetchFriendImageUrl(String imageName) async {
-  final ref = FirebaseStorage.instance.ref('friends-mypage/$imageName.webp');
-  return await ref.getDownloadURL();
+  try {
+    final ref = FirebaseStorage.instance.ref('friends-profile/$imageName.jpeg');
+    final imageUrl = await ref.getDownloadURL();
+    return imageUrl;
+  } catch (e) {
+    print('Error fetching image URL: $e');
+    return '';
+  }
 }
 
-final friendImageProvider =
-    FutureProvider.family<String, String>((ref, imageName) async {
+// 이미지 URL을 제공하는 Provider
+final imageProvider = FutureProvider.family<String, String>((ref, imageName) async {
   return await fetchFriendImageUrl(imageName);
 });
+
+//마지막 접속 시간을 일,시,분 별로 포멧팅해서 제공 해주는 함수
+String timeAgo(DateTime dateTime) {
+  final duration = DateTime.now().difference(dateTime);
+  if (duration.inDays > 1) {
+    return '${duration.inDays} days ago';
+  } else if (duration.inHours > 1) {
+    return '${duration.inHours} hours ago';
+  } else if (duration.inMinutes > 1) {
+    return '${duration.inMinutes} minutes ago';
+  } else {
+    return 'Just now';
+  }
+}

--- a/lib/feature/friend/provider/FriendsListProvider.dart
+++ b/lib/feature/friend/provider/FriendsListProvider.dart
@@ -12,7 +12,8 @@ final friendsListProvider = StreamProvider<List<FriendModel>>((ref) {
       final data = doc.data();
       return FriendModel.fromJson({
         ...data,
-        'lastConnect': (data['lastConnect'] as Timestamp).toDate().toIso8601String(),
+        'lastConnect':
+            (data['lastConnect'] as Timestamp).toDate().toIso8601String(),
       });
     }).toList();
   });
@@ -20,13 +21,13 @@ final friendsListProvider = StreamProvider<List<FriendModel>>((ref) {
 
 // friendImageURL을 가져오는 함수
 Future<String> fetchFriendImageUrl(String imageName) async {
-    final ref = FirebaseStorage.instance.ref('friends-profile/$imageName');
-    final imageUrl = await ref.getDownloadURL();
-    return imageUrl;
+  final ref = FirebaseStorage.instance.ref('friends-profile/$imageName');
+  final imageUrl = await ref.getDownloadURL();
+  return imageUrl;
 }
 
 // 이미지 URL을 제공하는 Provider
-final imageProvider = FutureProvider.family<String, String>((ref, imageName) async {
+final imageProvider =
+    FutureProvider.family<String, String>((ref, imageName) async {
   return await fetchFriendImageUrl(imageName);
 });
-

--- a/lib/feature/friend/provider/FriendsListProvider.dart
+++ b/lib/feature/friend/provider/FriendsListProvider.dart
@@ -4,12 +4,17 @@ import 'package:firebase_storage/firebase_storage.dart';
 
 import '../../../model/FriendModel.dart';
 
-
 // 친구 목록을 제공하는 Provider
 final friendsListProvider = StreamProvider<List<FriendModel>>((ref) {
   final firestore = FirebaseFirestore.instance;
   return firestore.collection('friends').snapshots().map((snapshot) {
-    return snapshot.docs.map((doc) => FriendModel.fromDocument(doc)).toList();
+    return snapshot.docs.map((doc) {
+      final data = doc.data();
+      return FriendModel.fromJson({
+        ...data,
+        'lastConnect': (data['lastConnect'] as Timestamp).toDate().toIso8601String(),
+      });
+    }).toList();
   });
 });
 
@@ -25,16 +30,3 @@ final imageProvider = FutureProvider.family<String, String>((ref, imageName) asy
   return await fetchFriendImageUrl(imageName);
 });
 
-//마지막 접속 시간을 일,시,분 별로 포멧팅해서 제공 해주는 함수
-String timeAgo(DateTime dateTime) {
-  final duration = DateTime.now().difference(dateTime);
-  if (duration.inDays > 1) {
-    return '${duration.inDays} days ago';
-  } else if (duration.inHours > 1) {
-    return '${duration.inHours} hours ago';
-  } else if (duration.inMinutes > 1) {
-    return '${duration.inMinutes} minutes ago';
-  } else {
-    return 'Just now';
-  }
-}

--- a/lib/feature/friend/provider/FriendsListProvider.dart
+++ b/lib/feature/friend/provider/FriendsListProvider.dart
@@ -19,15 +19,14 @@ final friendsListProvider = StreamProvider<List<FriendModel>>((ref) {
   });
 });
 
-// friendImageURL을 가져오는 함수
-Future<String> fetchFriendImageUrl(String imageName) async {
-  final ref = FirebaseStorage.instance.ref('friends-profile/$imageName');
-  final imageUrl = await ref.getDownloadURL();
-  return imageUrl;
-}
+// // 친구목록 이미지 URL을 제공하는 Provider
+// final friendsListImageProvider = FutureProvider.family<String, String>((ref, imageName) async {
+//   final ref = FirebaseStorage.instance.ref('friends-profile/$imageName');
+//   return await ref.getDownloadURL();
+// });
 
-// 이미지 URL을 제공하는 Provider
-final imageProvider =
-    FutureProvider.family<String, String>((ref, imageName) async {
-  return await fetchFriendImageUrl(imageName);
+/// 이미지 URL을 제공하는 공용 Provider
+final imageProvider = FutureProvider.family<String, String>((ref, imagePath) async {
+  final ref = FirebaseStorage.instance.ref(imagePath);
+  return await ref.getDownloadURL();
 });

--- a/lib/feature/friend/provider/FriendsListProvider.dart
+++ b/lib/feature/friend/provider/FriendsListProvider.dart
@@ -18,6 +18,7 @@ Future<String> fetchFriendImageUrl(String imageName) async {
   try {
     final ref = FirebaseStorage.instance.ref('friends-profile/$imageName.jpeg');
     final imageUrl = await ref.getDownloadURL();
+    print('프로바이더 패치 함수: $imageUrl'); // 로깅 추가
     return imageUrl;
   } catch (e) {
     print('Error fetching image URL: $e');

--- a/lib/feature/friend/widget/FriendBottomSheet.dart
+++ b/lib/feature/friend/widget/FriendBottomSheet.dart
@@ -13,6 +13,8 @@ class FriendBottomSheet extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    print('바텀시트 ${friend.name} image url: $imageUrl'); // 로깅 추가
+
     return Container(
       height: 280,
       decoration: BoxDecoration(

--- a/lib/feature/friend/widget/FriendBottomSheet.dart
+++ b/lib/feature/friend/widget/FriendBottomSheet.dart
@@ -13,7 +13,6 @@ class FriendBottomSheet extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    print('바텀시트 ${friend.name} image url: $imageUrl'); // 로깅 추가
 
     return Container(
       height: 280,
@@ -70,7 +69,7 @@ class FriendBottomSheet extends StatelessWidget {
                 ),
                 onPressed: () {
                   Navigator.of(context).pop();
-                  GoRouter.of(context).push('/chat'); // 채팅 페이지로 이동(현재 임의 경로)
+                  GoRouter.of(context).push('/chat');
                 },
                 child: const Text('채팅'),
               ),
@@ -83,7 +82,7 @@ class FriendBottomSheet extends StatelessWidget {
                 ),
                 onPressed: () {
                   Navigator.of(context).pop();
-                  GoRouter.of(context).push('/detail'); // 디테일 페이지로 이동(현재 임의 경로)
+                  GoRouter.of(context).push('/userdetail'); //현재 임의 경로 사용중 수정 필요
                 },
                 child: const Text('프로필'),
               ),

--- a/lib/feature/friend/widget/FriendBottomSheet.dart
+++ b/lib/feature/friend/widget/FriendBottomSheet.dart
@@ -1,0 +1,94 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../model/FriendModel.dart';
+
+
+class FriendBottomSheet extends StatelessWidget {
+  final FriendModel friend;
+  final String imageUrl;
+
+  const FriendBottomSheet({super.key, required this.friend, required this.imageUrl});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 280,
+      decoration: BoxDecoration(
+        color: Colors.grey[200],
+        borderRadius: const BorderRadius.vertical(
+          top: Radius.circular(25.0),
+        ),
+      ),
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(top: 10.0),
+            child: Row(
+              children: [
+                Container(
+                  width: 120,
+                  height: 120,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    border: Border.all(color: Colors.white, width: 4),
+                    image: DecorationImage(
+                      image: CachedNetworkImageProvider(imageUrl),
+                      fit: BoxFit.cover,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(friend.name, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 20)),
+                      const SizedBox(height: 8),
+                      Text(friend.status, style: const TextStyle(fontSize: 16)),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 24),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            children: [
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(horizontal: 54, vertical: 12),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+                onPressed: () {
+                  Navigator.of(context).pop();
+                  GoRouter.of(context).push('/chat'); // 채팅 페이지로 이동(현재 임의 경로)
+                },
+                child: const Text('채팅'),
+              ),
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(horizontal: 54, vertical: 12),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+                onPressed: () {
+                  Navigator.of(context).pop();
+                  GoRouter.of(context).push('/detail'); // 디테일 페이지로 이동(현재 임의 경로)
+                },
+                child: const Text('프로필'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/feature/friend/widget/FriendBottomSheet.dart
+++ b/lib/feature/friend/widget/FriendBottomSheet.dart
@@ -4,16 +4,15 @@ import 'package:go_router/go_router.dart';
 
 import '../../../model/FriendModel.dart';
 
-
 class FriendBottomSheet extends StatelessWidget {
   final FriendModel friend;
   final String imageUrl;
 
-  const FriendBottomSheet({super.key, required this.friend, required this.imageUrl});
+  const FriendBottomSheet(
+      {super.key, required this.friend, required this.imageUrl});
 
   @override
   Widget build(BuildContext context) {
-
     return Container(
       height: 280,
       decoration: BoxDecoration(
@@ -47,7 +46,9 @@ class FriendBottomSheet extends StatelessWidget {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(friend.name, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 20)),
+                      Text(friend.name,
+                          style: const TextStyle(
+                              fontWeight: FontWeight.bold, fontSize: 20)),
                       const SizedBox(height: 8),
                       Text(friend.status, style: const TextStyle(fontSize: 16)),
                     ],
@@ -62,7 +63,8 @@ class FriendBottomSheet extends StatelessWidget {
             children: [
               ElevatedButton(
                 style: ElevatedButton.styleFrom(
-                  padding: const EdgeInsets.symmetric(horizontal: 54, vertical: 12),
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 54, vertical: 12),
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(8),
                   ),
@@ -75,7 +77,8 @@ class FriendBottomSheet extends StatelessWidget {
               ),
               ElevatedButton(
                 style: ElevatedButton.styleFrom(
-                  padding: const EdgeInsets.symmetric(horizontal: 54, vertical: 12),
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 54, vertical: 12),
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(8),
                   ),

--- a/lib/feature/friend/widget/FriendListItemWidget.dart
+++ b/lib/feature/friend/widget/FriendListItemWidget.dart
@@ -9,7 +9,11 @@ class FriendListItemWidget extends StatelessWidget {
   final String imageUrl;
   final VoidCallback onTap;
 
-  const FriendListItemWidget({super.key, required this.friend, required this.imageUrl, required this.onTap});
+  const FriendListItemWidget(
+      {super.key,
+      required this.friend,
+      required this.imageUrl,
+      required this.onTap});
 
   @override
   Widget build(BuildContext context) {
@@ -42,7 +46,8 @@ class FriendListItemWidget extends StatelessWidget {
                   children: [
                     Text(lastConnect),
                     const SizedBox(height: 5),
-                    Text(friend.name, style: const TextStyle(fontWeight: FontWeight.bold)),
+                    Text(friend.name,
+                        style: const TextStyle(fontWeight: FontWeight.bold)),
                     Text(friend.status),
                   ],
                 ),

--- a/lib/feature/friend/widget/FriendListItemWidget.dart
+++ b/lib/feature/friend/widget/FriendListItemWidget.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 
 import '../../../model/FriendModel.dart';
 import '../../../utils/Formatter.dart';
-import '../provider/FriendsListProvider.dart';
 
 class FriendListItemWidget extends StatelessWidget {
   final FriendModel friend;

--- a/lib/feature/friend/widget/FriendListItemWidget.dart
+++ b/lib/feature/friend/widget/FriendListItemWidget.dart
@@ -9,12 +9,7 @@ class FriendListItemWidget extends StatelessWidget {
   final String imageUrl;
   final VoidCallback onTap;
 
-  const FriendListItemWidget({
-    super.key,
-    required this.friend,
-    required this.imageUrl,
-    required this.onTap,
-  });
+  const FriendListItemWidget({super.key, required this.friend, required this.imageUrl, required this.onTap});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/feature/friend/widget/FriendListItemWidget.dart
+++ b/lib/feature/friend/widget/FriendListItemWidget.dart
@@ -1,56 +1,69 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 
 import '../../../model/FriendModel.dart';
+import '../provider/FriendsListProvider.dart';
 
 class FriendListItemWidget extends StatelessWidget {
   final FriendModel friend;
+  final String imageUrl;
+  final VoidCallback onTap;
 
-  const FriendListItemWidget({super.key, required this.friend});
+  const FriendListItemWidget({
+    super.key,
+    required this.friend,
+    required this.imageUrl,
+    required this.onTap,
+  });
 
   @override
   Widget build(BuildContext context) {
+    final lastConnect = timeAgo(friend.lastConnect);
+
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 10.0, vertical: 5.0),
-      child: Container(
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(15),
-          border: Border.all(
-            color: Colors.grey.shade300,
-            width: 1.0,
+      child: GestureDetector(
+        onTap: onTap,
+        child: Container(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(20),
+            border: Border.all(
+              color: Colors.grey.shade300,
+              width: 1.0,
+            ),
           ),
-        ),
-        child: Column(
-          children: [
-            ListTile(
-              leading: CircleAvatar(
-                radius: 30,
-                backgroundImage: friend.imageUrl.isNotEmpty
-                    ? NetworkImage(friend.imageUrl)
-                    : null, //대체 이미지 추가 필요
+          child: Column(
+            children: [
+              ListTile(
+                leading: CircleAvatar(
+                  radius: 25,
+                  backgroundImage: CachedNetworkImageProvider(imageUrl),
+                  onBackgroundImageError: (exception, stackTrace) {
+                    print('Error loading image: $exception');
+                  },
+                ),
+                title: Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    Text(lastConnect),
+                    const SizedBox(height: 5),
+                    Text(friend.name, style: const TextStyle(fontWeight: FontWeight.bold)),
+                    Text(friend.status),
+                  ],
+                ),
               ),
-              title: Column(
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: [
-                  Text(friend.lastConnect.toString()),
-                  const SizedBox(height: 5),
-                  Text(friend.name,
-                      style: const TextStyle(fontWeight: FontWeight.bold)),
-                  Text(friend.status),
-                ],
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8.0, left: 20.0),
+                child: Row(
+                  children: [
+                    const Icon(Icons.favorite, color: Colors.red),
+                    const SizedBox(width: 5),
+                    Text(friend.likes.toString()),
+                  ],
+                ),
               ),
-            ),
-            Padding(
-              padding: const EdgeInsets.only(bottom: 8.0, left: 16.0),
-              // left padding added
-              child: Row(
-                children: [
-                  const Icon(Icons.favorite, color: Colors.red),
-                  const SizedBox(width: 5),
-                  Text(friend.likes.toString()),
-                ],
-              ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/feature/friend/widget/FriendListItemWidget.dart
+++ b/lib/feature/friend/widget/FriendListItemWidget.dart
@@ -2,6 +2,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 
 import '../../../model/FriendModel.dart';
+import '../../../utils/Formatter.dart';
 import '../provider/FriendsListProvider.dart';
 
 class FriendListItemWidget extends StatelessWidget {

--- a/lib/feature/friend/widget/FriendsListWidget.dart
+++ b/lib/feature/friend/widget/FriendsListWidget.dart
@@ -21,7 +21,6 @@ class FriendsListWidget extends ConsumerWidget {
             final imageUrl = ref.watch(imageProvider(friend.imageName));
             return imageUrl.when(
               data: (imageUrl) {
-                print('프렌즈리스트위젯 ${friend.name}: $imageUrl'); // 로깅 추가
                 return FriendListItemWidget(
                   friend: friend,
                   imageUrl: imageUrl,

--- a/lib/feature/friend/widget/FriendsListWidget.dart
+++ b/lib/feature/friend/widget/FriendsListWidget.dart
@@ -14,39 +14,46 @@ class FriendsListWidget extends ConsumerWidget {
 
     return friendList.when(
       data: (friends) {
-        return ListView.builder(
-          itemCount: friends.length,
-          itemBuilder: (context, index) {
-            final friend = friends[index];
-            final imageUrl = ref.watch(imageProvider(friend.imageName));
-            return imageUrl.when(
-              data: (imageUrl) {
-                return FriendListItemWidget(
-                  friend: friend,
-                  imageUrl: imageUrl,
-                  onTap: () {
-                    showModalBottomSheet(
-                      context: context,
-                      isScrollControlled: true,
-                      shape: const RoundedRectangleBorder(
-                        borderRadius: BorderRadius.vertical(
-                          top: Radius.circular(25.0),
-                        ),
-                      ),
-                      builder: (context) => FriendBottomSheet(
-                        friend: friend,
-                        imageUrl: imageUrl,
-                      ),
-                    );
-                  },
-                );
-              },
-              loading: () => const Center(child: CircularProgressIndicator()),
-              error: (error, stack) {
-                print('Error loading image: $error');
-              },
-            );
+        return RefreshIndicator(
+          onRefresh: () async {
+            ref.refresh(friendsListProvider);
           },
+          child: ListView.builder(
+            itemCount: friends.length,
+            itemBuilder: (context, index) {
+              final friend = friends[index];
+              final imageUrl = ref.watch(imageProvider(friend.imageName));
+              return imageUrl.when(
+                data: (imageUrl) {
+                  return FriendListItemWidget(
+                    friend: friend,
+                    imageUrl: imageUrl,
+                    onTap: () {
+                      showModalBottomSheet(
+                        context: context,
+                        isScrollControlled: true,
+                        shape: const RoundedRectangleBorder(
+                          borderRadius: BorderRadius.vertical(
+                            top: Radius.circular(25.0),
+                          ),
+                        ),
+                        builder: (context) => FriendBottomSheet(
+                          friend: friend,
+                          imageUrl: imageUrl,
+                        ),
+                      );
+                    },
+                  );
+                },
+                loading: () => const Center(child: CircularProgressIndicator()),
+                error: (error, stack) {
+                  return const ListTile(
+                    title: Text('Error loading image'),
+                  );
+                },
+              );
+            },
+          ),
         );
       },
       loading: () => const Center(child: CircularProgressIndicator()),

--- a/lib/feature/friend/widget/FriendsListWidget.dart
+++ b/lib/feature/friend/widget/FriendsListWidget.dart
@@ -22,8 +22,10 @@ class FriendsListWidget extends ConsumerWidget {
             itemCount: friends.length,
             itemBuilder: (context, index) {
               final friend = friends[index];
-              final imageUrl = ref.watch(imageProvider(friend.imageName));
-              return imageUrl.when(
+              // final imageUrl = ref.watch(imageProvider(friend.imageName));
+              final friendListImageUrl = ref.watch(imageProvider('friends-profile/${friend.imageName}'));
+
+              return friendListImageUrl.when(
                 data: (imageUrl) {
                   return FriendListItemWidget(
                     friend: friend,

--- a/lib/feature/friend/widget/FriendsListWidget.dart
+++ b/lib/feature/friend/widget/FriendsListWidget.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+
 import '../provider/FriendsListProvider.dart';
+import 'FriendBottomSheet.dart';
 import 'FriendListItemWidget.dart';
 
 class FriendsListWidget extends ConsumerWidget {
@@ -15,7 +17,35 @@ class FriendsListWidget extends ConsumerWidget {
         return ListView.builder(
           itemCount: friends.length,
           itemBuilder: (context, index) {
-            return FriendListItemWidget(friend: friends[index]);
+            final friend = friends[index];
+            final imageUrl = ref.watch(imageProvider(friend.imageName));
+            return imageUrl.when(
+              data: (imageUrl) {
+                return FriendListItemWidget(
+                  friend: friend,
+                  imageUrl: imageUrl,
+                  onTap: () {
+                    showModalBottomSheet(
+                      context: context,
+                      isScrollControlled: true,
+                      shape: const RoundedRectangleBorder(
+                        borderRadius: BorderRadius.vertical(
+                          top: Radius.circular(25.0),
+                        ),
+                      ),
+                      builder: (context) => FriendBottomSheet(
+                        friend: friend,
+                        imageUrl: imageUrl,
+                      ),
+                    );
+                  },
+                );
+              },
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (error, stack) {
+                print('Error loading image: $error');
+              },
+            );
           },
         );
       },

--- a/lib/feature/friend/widget/FriendsListWidget.dart
+++ b/lib/feature/friend/widget/FriendsListWidget.dart
@@ -21,6 +21,7 @@ class FriendsListWidget extends ConsumerWidget {
             final imageUrl = ref.watch(imageProvider(friend.imageName));
             return imageUrl.when(
               data: (imageUrl) {
+                print('프렌즈리스트위젯 ${friend.name}: $imageUrl'); // 로깅 추가
                 return FriendListItemWidget(
                   friend: friend,
                   imageUrl: imageUrl,

--- a/lib/feature/report/widget/ReportUserButton.dart
+++ b/lib/feature/report/widget/ReportUserButton.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+class ReportUserButton extends StatelessWidget {
+  final String reportedUserId;
+
+  const ReportUserButton({super.key, required this.reportedUserId});
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      icon: const Icon(Icons.report),
+      onPressed: () => _showReportDialog(context),
+    );
+  }
+
+  void _showReportDialog(BuildContext context) {
+    final TextEditingController _controller = TextEditingController();
+
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text("Report User"),
+          content: TextField(
+            controller: _controller,
+            decoration: const InputDecoration(hintText: "Enter your report reason"),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+              child: const Text("Cancel"),
+            ),
+            TextButton(
+              onPressed: () {
+                _reportUser(_controller.text);
+                Navigator.of(context).pop();
+              },
+              child: const Text("Report"),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Future<void> _reportUser(String reason) async {
+    User? currentUser = FirebaseAuth.instance.currentUser;
+    if (currentUser != null) {
+      await FirebaseFirestore.instance.collection('reports').add({
+        'reportedUserId': reportedUserId,
+        'reporterUserId': currentUser.uid,
+        'reason': reason,
+        'timestamp': FieldValue.serverTimestamp(),
+      });
+    }
+  }
+}

--- a/lib/model/FriendModel.dart
+++ b/lib/model/FriendModel.dart
@@ -15,5 +15,6 @@ class FriendModel with _$FriendModel {
     required DateTime lastConnect,
   }) = _FriendModel;
 
-  factory FriendModel.fromJson(Map<String, dynamic> json) => _$FriendModelFromJson(json);
+  factory FriendModel.fromJson(Map<String, dynamic> json) =>
+      _$FriendModelFromJson(json);
 }

--- a/lib/model/FriendModel.dart
+++ b/lib/model/FriendModel.dart
@@ -21,6 +21,7 @@ class FriendModel with _$FriendModel {
   // DocumentSnapshot에서 FriendModel 객체로 변환하는 팩토리 메서드
   factory FriendModel.fromDocument(DocumentSnapshot doc) {
     final data = doc.data() as Map<String, dynamic>;
+    print('프렌드 모델: $data'); // 로깅 추가
     return FriendModel(
       userId: data['userId'] as String,
       friendId: data['friendId'] as String,

--- a/lib/model/FriendModel.dart
+++ b/lib/model/FriendModel.dart
@@ -1,3 +1,4 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'generated/FriendModel.freezed.dart';
@@ -10,11 +11,24 @@ class FriendModel with _$FriendModel {
     required String friendId,
     required String name,
     required String status,
-    required String imageUrl,
+    required String imageName,
     required int likes,
     required DateTime lastConnect,
   }) = _FriendModel;
 
-  factory FriendModel.fromJson(Map<String, dynamic> json) =>
-      _$FriendModelFromJson(json);
+  factory FriendModel.fromJson(Map<String, dynamic> json) => _$FriendModelFromJson(json);
+
+  // DocumentSnapshot에서 FriendModel 객체로 변환하는 팩토리 메서드
+  factory FriendModel.fromDocument(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
+    return FriendModel(
+      userId: data['userId'] as String,
+      friendId: data['friendId'] as String,
+      name: data['name'] as String,
+      status: data['status'] as String,
+      imageName: data['imageName'] as String,
+      likes: data['likes'] as int,
+      lastConnect: (data['lastConnect'] as Timestamp).toDate(),
+    );
+  }
 }

--- a/lib/model/FriendModel.dart
+++ b/lib/model/FriendModel.dart
@@ -17,18 +17,4 @@ class FriendModel with _$FriendModel {
   }) = _FriendModel;
 
   factory FriendModel.fromJson(Map<String, dynamic> json) => _$FriendModelFromJson(json);
-
-  // DocumentSnapshot에서 FriendModel 객체로 변환하는 팩토리 메서드
-  factory FriendModel.fromDocument(DocumentSnapshot doc) {
-    final data = doc.data() as Map<String, dynamic>;
-    return FriendModel(
-      userId: data['userId'] as String,
-      friendId: data['friendId'] as String,
-      name: data['name'] as String,
-      status: data['status'] as String,
-      imageName: data['imageName'] as String,
-      likes: data['likes'] as int,
-      lastConnect: (data['lastConnect'] as Timestamp).toDate(),
-    );
-  }
 }

--- a/lib/model/FriendModel.dart
+++ b/lib/model/FriendModel.dart
@@ -1,4 +1,3 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'generated/FriendModel.freezed.dart';

--- a/lib/model/FriendModel.dart
+++ b/lib/model/FriendModel.dart
@@ -21,7 +21,6 @@ class FriendModel with _$FriendModel {
   // DocumentSnapshot에서 FriendModel 객체로 변환하는 팩토리 메서드
   factory FriendModel.fromDocument(DocumentSnapshot doc) {
     final data = doc.data() as Map<String, dynamic>;
-    print('프렌드 모델: $data'); // 로깅 추가
     return FriendModel(
       userId: data['userId'] as String,
       friendId: data['friendId'] as String,

--- a/lib/utils/Formatter.dart
+++ b/lib/utils/Formatter.dart
@@ -4,3 +4,19 @@ String formatWonNumber(int number) {
   final formatter = NumberFormat('#,###', 'en_US');
   return formatter.format(number);
 }
+
+///마지막 접속 시간을 일, 시, 분 별로 포멧팅해서 제공 해주는 함수입니다.
+///
+///마지막 접속 시간 = 현재 시간 - 유저의 최종 접속 시간
+String timeAgo(DateTime dateTime) {
+  final duration = DateTime.now().difference(dateTime);
+  if (duration.inDays > 1) {
+    return '${duration.inDays} days ago';
+  } else if (duration.inHours > 1) {
+    return '${duration.inHours} hours ago';
+  } else if (duration.inMinutes > 1) {
+    return '${duration.inMinutes} minutes ago';
+  } else {
+    return 'Just now';
+  }
+}


### PR DESCRIPTION
## 설명
친구목록 페이지의 리펙토링 pr입니다.

## 변경 사항

- 변경 1
firebase database 에 이미지 확장자까지 저장하도록 수정
(코드에서 확장자를 정해버리는 부분을 삭제하였습니다)

- 변경 2
friendModel 경량화 : document 로직 삭제하고 작동하도록 수정
(보일러플레이트를 없애려고 쓰는 freezed 사용의의와 어긋나는것 같아 모델 내부 기타 로직을 삭제하였습니다)

- 변경 3
friendsListProvider에 있던 timeAgo 함수를 util 폴더 formattor.dart로 이동 
(최근 접속 시간을 포멧팅해주는 함수는 공용으로 쓰일것 같아 util 폴더로 이동 시켰습니다)

- 변경 4
친구목록에 RefreshIndicator 적용 및 테스트 완료


## 체크리스트
< 체크리스트 항목을 확인해 주세요. >

- [x] 오늘도 행복하게 코딩했는가?
- [x] 모든 수정 완료 후 `make` 커맨드를 터미널에서 실행하였는가?
- [x] release 브랜치를 제대로 최신화 하고 이 브랜치에 merge 했는가?
- [x] PR 제목은 명확하고 간결한가?
- [ ] PR 에는 하나의 작업에 대한 내용만 포함되었는가?
- [x] 파일명은 누구나 이해할 수 있게 작성되었는가?
- [x] camelCase를 사용하였는가? (ThisIsCamelCase, this_is_not_camel_case)
- [x] 텍스트는 AppStrings.dart 파일에서 가져오고 있는가?
- [x] 디스코드 채팅방에 완료된 태스크를 알렸는가?

## 스크린샷
<img alt="친구목록화면" width="240" src="https://github.com/user-attachments/assets/81be94b6-4709-46cf-bfb5-d65adede869f">


## 참조

관련된 이슈나 PR이 있다면 링크를 추가해주세요.
