### PR TITLE
회원가입 페이지 내부에서 버그 수정 

### DIFF
--- a/lib/feature/phoneauth/ConfirmationPage.dart
+++ b/lib/feature/phoneauth/ConfirmationPage.dart
@@ -64,6 +64,8 @@ class ConfirmationPage extends ConsumerWidget {
                 // 오류 뱉어내는거 하나 만들어야함 ex ) ID or Password 형식에 문제가 있다라고 쏴야할듯 ?
                 await firebaseService.upDateUserDB(email, name);
                 FirebaseAnalytics.instance.logSignUp(signUpMethod: 'email');
+                ref.invalidate(emailProvider);
+                ref.invalidate(passwordConfirmProvider);
                 if (context.mounted) {
                   context.goNamed(TopScreen.name);
                 }

--- a/lib/feature/signup/SignUpScreen.dart
+++ b/lib/feature/signup/SignUpScreen.dart
@@ -28,8 +28,6 @@ class SignUpScreen extends ConsumerStatefulWidget {
 class _SignUpScreenState extends ConsumerState<SignUpScreen> {
   @override
   Widget build(BuildContext context) {
-    ref.watch(emailProvider);
-    ref.watch(passwordConfirmProvider);
     return Scaffold(
       appBar: AppBar(
         leading: IconButton(

--- a/lib/feature/signup/provider/SignUpDataProviders.dart
+++ b/lib/feature/signup/provider/SignUpDataProviders.dart
@@ -1,7 +1,7 @@
 // 이메일 인증 ( 아이디 )
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-final emailProvider = StateProvider.autoDispose<String>((ref) => '');
+final emailProvider = StateProvider<String>((ref) => '');
 final emailVerificationCodeProvider = StateProvider<String>((ref) => '');
 
 // 이름, 닉네임 생성
@@ -10,7 +10,7 @@ final nicknameProvider = StateProvider.autoDispose<String>((ref) => '');
 
 // 비밀번호 생성
 final passwordProvider = StateProvider.autoDispose<String>((ref) => '');
-final passwordConfirmProvider = StateProvider.autoDispose<String>((ref) => '');
+final passwordConfirmProvider = StateProvider<String>((ref) => '');
 
 // 휴대폰 번호 인증 ( 구매할 때 휴대폰 인증 ) ( 따로 만들기 )
 final residentRegistrationNumberProvider =


### PR DESCRIPTION
## 설명
페이지뷰 내부에서 StateProvider를 사용하게되면 유통기한이 2페이지를 초과하면 autoDispose가 켜져있을경우 3번째 페이지로 이동하게 되면 종료됩니다. 이 부분을 해결하기 위해, PageView최상단에 선언하는것을 해봤으나 텍스트 필드에 입력이 들어가지 않는 이슈가 있어서, 삭제하고 
마지막 회원 가입 승인 직전에 invalidate처리로 날려버리는게 맞다고 생각해서 수정합니다
정상 동작 다시 하는지 확인 완료 

## 변경 사항

- SignUpScrenn에서 이메일과 비밀번호를 잡고있던 프로바이더 삭제
- 마지막에 최종 가입직전 처리로 수정 

## 체크리스트
< 체크리스트 항목을 확인해 주세요. >

- [x] 오늘도 행복하게 코딩했는가?
- [x] 모든 수정 완료 후 `make` 커맨드를 터미널에서 실행하였는가?
- [x] release 브랜치를 제대로 최신화 하고 이 브랜치에 merge 했는가?
- [x] PR 제목은 명확하고 간결한가?
- [x] PR 에는 하나의 작업에 대한 내용만 포함되었는가?
- [x] 파일명은 누구나 이해할 수 있게 작성되었는가?
- [x] camelCase를 사용하였는가? (ThisIsCamelCase, this_is_not_camel_case)
- [x] 텍스트는 AppStrings.dart 파일에서 가져오고 있는가?
- [x] 디스코드 채팅방에 완료된 태스크를 알렸는가?

## 스크린샷
< 여기에 이미지/동영상을 드래그 앤 드랍하면 링크가 생성됩니다. > 
<img alt="sample" width="240" src="여기에 링크를 추가해주세요">
<video alt="sample" width="240" src="여기에 링크를 추가해주세요">

## 참조

관련된 이슈나 PR이 있다면 링크를 추가해주세요.
